### PR TITLE
Add dependency to util migration

### DIFF
--- a/postgresqleu/util/migrations/0002_bytea_smarter_storage.py
+++ b/postgresqleu/util/migrations/0002_bytea_smarter_storage.py
@@ -9,6 +9,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('util', '0001_initial'),
+        ('confsponsor', '0018_contract_storage_inline')
     ]
 
     operations = [


### PR DESCRIPTION
util migration 0002 changes the type of util_storage.data from text to
bytea but confsponsor migration 0018 assumes this column is text when
updating confsponsor_sponsorshipcontract.contractpdf. Adding explicity
dependency between the two ensures they are processed in the correct
order.