### PR TITLE
Move `migrate_membership_config` to later migration

### DIFF
--- a/postgresqleu/membership/migrations/0004_membership_config.py
+++ b/postgresqleu/membership/migrations/0004_membership_config.py
@@ -10,16 +10,6 @@ from postgresqleu.util.fields import LowercaseEmailField
 from postgresqleu.membership.models import MembershipConfiguration
 
 
-def migrate_membership_config(apps, schema_editor):
-    config = MembershipConfiguration(
-        id=1,
-        sender_email=getattr(settings, 'MEMBERSHIP_SENDER_EMAIL', settings.DEFAULT_EMAIL),
-        membership_years=getattr(settings, 'MEMBERSHIP_LENGTH', 1),
-        membership_cost=getattr(settings, 'MEMBERSHIP_COST', 10),
-    )
-    config.save()
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -40,6 +30,5 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.RunSQL("ALTER TABLE membership_membershipconfiguration ADD CONSTRAINT highlander CHECK (id=1)"),
-        migrations.RunPython(migrate_membership_config),
         migrations.RunSQL("INSERT INTO membership_membershipconfiguration_paymentmethods (membershipconfiguration_id, invoicepaymentmethod_id) SELECT 1, id FROM invoices_invoicepaymentmethod WHERE active AND auto"),
     ]

--- a/postgresqleu/membership/migrations/0005_membership_sender_name.py
+++ b/postgresqleu/membership/migrations/0005_membership_sender_name.py
@@ -3,6 +3,17 @@
 from django.db import migrations, models
 from django.conf import settings
 
+from postgresqleu.membership.models import MembershipConfiguration
+
+
+def migrate_membership_config(apps, schema_editor):
+    config = MembershipConfiguration(
+        id=1,
+        sender_email=getattr(settings, 'MEMBERSHIP_SENDER_EMAIL', settings.DEFAULT_EMAIL),
+        membership_years=getattr(settings, 'MEMBERSHIP_LENGTH', 1),
+        membership_cost=getattr(settings, 'MEMBERSHIP_COST', 10),
+    )
+    config.save()
 
 class Migration(migrations.Migration):
 
@@ -17,4 +28,5 @@ class Migration(migrations.Migration):
             field=models.CharField(default=settings.ORG_NAME, help_text='Name to use as sender on outgoing email', max_length=100),
             preserve_default=False,
         ),
+        migrations.RunPython(migrate_membership_config),
     ]


### PR DESCRIPTION
Calling `config.save()` tries to persist `sender_name` to
`membership_membershipconfiguration` but this field isn't added until a
subsequent migration.