### PR TITLE
form didn't exist and newform doesn't have this field.

### DIFF
--- a/postgresqleu/util/backendviews.py
+++ b/postgresqleu/util/backendviews.py
@@ -73,7 +73,6 @@ def backend_process_form(request, urlname, formclass, id, cancel_url='../', save
                         'basetemplate': basetemplate,
                         'topadmin': topadmin,
                         'form': newform,
-                        'note': form.formnote,
                         'whatverb': 'Create new',
                         'what': formclass._verbose_name(),
                         'savebutton': 'Create',


### PR DESCRIPTION
I was getting a error trying to add a new payment gateway as form doesn't exist. newform doesn't have the note field so made sense just to remove it.