### PR TITLE
Create a Dockerfile to ease development

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,7 @@ working on new features, please reach out to us first and discuss your feature
 idea.  Once a feature has been discussed and the general concept agreed to, a
 feature issue can be opened to work on the details of the implementation.
 
+For practical details and guides for developing the pgeu-system, please consult
+the file [tools/devsetup/README.txt](tools/devsetup/README.txt)
+
 The mailing list for discussing pgeu-system is <pgeu-system@lists.postgresql.eu>.

--- a/tools/devsetup/Dockerfile
+++ b/tools/devsetup/Dockerfile
@@ -1,0 +1,92 @@
+# Download base image ubuntu 18.04
+FROM ubuntu:18.04
+
+# LABEL the image
+LABEL maintainer="pgeu-system@lists.postgresql.eu"
+LABEL version="0.1"
+LABEL description="This is a base development environment for the \
+PostgreSQL Europe Conference Management System"
+
+# Avoid interactive packages
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Update to the latest version and install basic packages
+RUN apt-get update && apt-get -y install wget \
+										 sudo \
+										 apt-utils \
+										 gnupg gnupg1 gnupg2 \
+										 lsb-release
+
+# Install postgres, start with the required repo
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc  > /tmp/key
+RUN sudo apt-key add /tmp/key
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+
+# Update again and install postgres
+RUN apt-get update && apt-get install -y \
+	postgresql-13 \
+	postgresql-client-13 \
+	postgresql-server-dev-13
+
+# Make it part of the path
+ENV PATH="/usr/lib/postgresql/13/bin:${PATH}"
+
+# Install the rest of the essential packages
+RUN apt-get update && apt-get install -y \
+	python3.7 \
+	virtualenv \
+	python3-virtualenv \
+	build-essential \
+	python-dev \
+	libffi-dev \
+	libssl-dev \
+	libjpeg-dev \
+	libpng-dev \
+	libqrencode-dev \
+	uwsgi \
+	uwsgi-plugin-python3 \
+	python3-pip
+
+# Create the user to be used with bash for interactive sessions
+RUN useradd -s /bin/bash -U -G sudo,postgres,root pgeusystem
+
+# Install the pip requirements
+WORKDIR /opt/pgeusystem/setup
+COPY ./tools/devsetup/dev_requirements.txt .
+RUN pip3 install -r dev_requirements.txt
+
+# Create the datadir, db and user for out app
+USER root
+WORKDIR /opt/pgeusystem/pgdata
+RUN chown -R pgeusystem.pgeusystem /opt/pgeusystem/pgdata
+USER pgeusystem
+RUN pg_ctl -D /opt/pgeusystem/pgdata initdb
+RUN pg_ctl -D /opt/pgeusystem/pgdata -l /opt/pgeusystem/pgdata/logfile start \
+	&& psql -c 'CREATE DATABASE pgeusystem' postgres \
+	&& psql -c 'GRANT ALL PRIVILEGES ON DATABASE pgeusystem TO pgeusystem' pgeusystem \
+	&& pg_ctl -D /opt/pgeusystem/pgdata stop
+
+# Get the app in place
+USER root
+WORKDIR /opt/pgeusystem/app
+RUN chown -R pgeusystem.pgeusystem /opt/pgeusystem/app
+USER pgeusystem
+COPY . /opt/pgeusystem/app
+
+# Create the ini files using the scripts
+WORKDIR /opt/pgeusystem/app
+USER pgeusystem
+RUN pg_ctl -D /opt/pgeusystem/pgdata -l /opt/pgeusystem/pgdata/logfile start \
+	&& ./tools/devsetup/dev_setup.sh localhost 5432 pgeusystem pgeusystem \
+	&& pg_ctl -D /opt/pgeusystem/pgdata stop
+
+# Create a file to run the app
+WORKDIR /opt/pgeusystem/app
+USER pgeusystem
+RUN echo "#!/bin/bash\n\
+		  pg_ctl -D /opt/pgeusystem/pgdata -l /opt/pgeusystem/pgdata/logfile start\n\
+		  uwsgi --ini devserver-uwsgi.ini\n" > startup.sh
+RUN chmod +x startup.sh
+
+# Launch it
+CMD ["./startup.sh"]

--- a/tools/devsetup/README.txt
+++ b/tools/devsetup/README.txt
@@ -36,3 +36,28 @@ macOS support
 -------------
 All required dependencies except virtualenv can be installed via Homebrew,
 virtualenv is installed with pip.
+
+
+Dockerfile
+----------
+
+A Dockerfile is present to showcase the needed installation and how to run the
+app. The base image is based on ubuntu 18.04 LTS, which can also be used for
+development should one wishes to. The admin name for the app and the database,
+as well as the name of the database itself is set to 'pgeusystem'.
+
+A typical usecase would be to build the docker image via:
+	$ docker build -t pgeusystem-image -f ./tools/devsetup/Dockerfile .
+from the base directory.
+
+Then run said image in the background using the host's network via:
+	$ docker run --name pgeusystem-image  --network host -d  pgeusystem-image
+
+If the above commands are successfull then one can reach the index page of the
+app in http://localhost:8012
+
+If the user so wishes, can reach the database in the running container via:
+	$ psql -h localhost -U pgeusystem pgeusystem
+
+Finally to stop the running image from running, issue:
+	$ docker container stop pgeusystem-image


### PR DESCRIPTION
Additionally document in code the required setup and have an example of use. It
is by no means intended to be run in production.

The base image is from ubuntu 18.04 LTS which is the most recent version of
ubuntu that can match the python/pip/virtualenv requirements. For example ubuntu
20.04 will require Pillow 6.2 instead of 5.4.1 and virtualenv will have to be
launched without the -no-site-packages option.

The setup is based on the name pgeusystem which is used throughout, e.g. admin
name, db name etc.

Some basic instructions on how to build, run and use the image are added to the
README on the devsetup directory, which by itself is now listed in the root
README file to provide visibility.