### PR TITLE
Improve experience when changing status on voting page

### DIFF
--- a/template/confreg/sessionvotes.html
+++ b/template/confreg/sessionvotes.html
@@ -92,8 +92,11 @@ function doUpdateStatus(id, statusval) {
 }
 
 function changeStatus(id) {
-   var currentstatus = $('#statusstr' + id).data('currstatus');
    var buttons = {};
+   var currentstatus = $('#statusstr' + id).data('currstatus');
+   var offset = $('#statusstr' + id).offset();
+   var height = $('#statusstr' + id).height();
+
    $.each(valid_status_transitions[currentstatus], function(k,v) {
       buttons[v] = function(event) {
          doUpdateStatus(id, k);
@@ -105,10 +108,15 @@ function changeStatus(id) {
    };
 
    $('#dlgStatus').dialog('option', {
-      'title': 'Change status',
+      'title': 'Change status [id: ' + id + ']',
       'modal': true,
    }).dialog('option', {
      buttons: buttons,
+   }).dialog('option', {
+     position: [
+       offset.left,
+       offset.top + height
+     ],
    }).dialog('open');
 }
 


### PR DESCRIPTION
One of the ways to change the status of a submission is to click on the submission's status link. Then a pop up dialogue appears. However the placement of the pop up is not relative to the submission. It may be end up being away from the current viewport, based on the browser used and the length of the page.

Mitigate by explicitly placing the dialogue relative to the clicked event. While at it, add the submission's id on the dialogue's title so that there may not be any confusion as to which submission is being edited.