### PR TITLE
Fix broken links in the documentation

### DIFF
--- a/docs/confreg/callforpapers.md
+++ b/docs/confreg/callforpapers.md
@@ -7,7 +7,7 @@ Running a call for papers consists of a few clearly separated steps:
 ### 1. Collecting proposals
 
 To start collecting proposals, enable the call for papers on the
-[conference](configuring). As soon as this is done, speakers can start
+[conference](configuring.md). As soon as this is done, speakers can start
 submitting entries. Before doing that, make sure you configure the
 introductory text (if you want one), and decide if you want to ask for
 skill levels.
@@ -66,7 +66,7 @@ voting page or by visiting 'Pending notifications' from the dashboard!
 
 Once a session has entered the *approved* state, it will show up in
 the list of sessions, if that is enabled for the
-[conference](configuring).
+[conference](configuring.md).
 
 See below for a diagram of how a session moves through the different
 states.

--- a/docs/confreg/configuring.md
+++ b/docs/confreg/configuring.md
@@ -8,7 +8,7 @@ completely new conference, see the [separate page](super_conference#new).
 
 There are a few base configuration steps to always perform.
 
-Set the maximum number of attendees before the [waitlist](waitlist)
+Set the maximum number of attendees before the [waitlist](waitlist.md)
 activates. This should always be set to a few below venue capacity, to
 make sure a multireg doesn't "break the bank".
 
@@ -28,10 +28,10 @@ Decide if you want a welcome email to be sent to all attendees when
 their registration is fully completed (payment confirmed), which is
 normally recommended. If you do, of course also set the text of that
 email. The email will be sent from the address configured as the
-contact address by the [superuser](super_conference).
+contact address by the [superuser](super_conference.md).
 
 If needed, add a text added as a prefix before the
-[additional options](registrations) listing on the registration form.
+[additional options](registrations.md) listing on the registration form.
 
 ### Registration fields
 
@@ -44,17 +44,17 @@ exists on all attendees.
 ### Workflow steps
 
 You can separately enable each of the different user workflow steps
-for [registration](registrations), [call for papers](callforpapers),
-[call for sponsors](sponsors), [schedule](schedule) and
-[feedback](feedback). Make sure you don't enable any steps until the
+for [registration](registrations.md), [call for papers](callforpapers.md),
+[call for sponsors](sponsors.md), [schedule](schedule.md) and
+[feedback](feedback.md). Make sure you don't enable any steps until the
 organisation is ready for it.
 
 ### Call for papers
 
 Decide if you want skill level prompts in the
-[call for papers](callforpapers) and visible in the
-[schedule](schedule), and set the intro text used on the
-[call for papers](callforpapers).
+[call for papers](callforpapers.md) and visible in the
+[schedule](schedule.md), and set the intro text used on the
+[call for papers](callforpapers.md).
 
 You can also decide if you want talkvoters to be able to see how others
 voted and the overall average vote.  Usually this would be off until
@@ -69,28 +69,28 @@ Testers are users that can bypass the restrictions on which parts of
 the workflow are open, e.g. they can perform a registration even if
 registrations are closed. The idea is that this can be used for
 example to test skinning functions, and to validate the setup of
-things like [registration types](registrations).
+things like [registration types](registrations.md).
 
 Talkvoters are users that can vote on talks in the
-[call for papers](callforpapers).
+[call for papers](callforpapers.md).
 
-Staff are users who are allowed to [register](registrations) with a
+Staff are users who are allowed to [register](registrations.md) with a
 registration that requires staff (basically intended for free or
 discounted registrations). This is assigned to users *before* they
 register, to gain access to this registration type.
 
 Volunteers are *registered* users who can participate in the
-[volunteer schedule](volunteers). Note that this requires the users to
+[volunteer schedule](volunteers.md). Note that this requires the users to
 actually be registered for the conference in order to be
 selected. This is a separate flag instead of a registration type so
 that it's easy to for example have attendees who are both speakers and
 on the volunteer schedule. If volunteers should get free entry as
 well, that is typically handled either with a
-[registration type](registrations) that requires manual validation, or
-with a custom [voucher or discount code](vouchers).
+[registration type](registrations.md) that requires manual validation, or
+with a custom [voucher or discount code](vouchers.md).
 
 The final role that exists in a conference is an administrator. This
-can only be assigned by a [superuser](super_conference).
+can only be assigned by a [superuser](super_conference.md).
 
 ## Reference
 
@@ -99,7 +99,7 @@ can only be assigned by a [superuser](super_conference).
 The form to edit a conference has the following fields:
 
 Attendees before waitlist
-: Number of confirmed attendees before the [waitlist](waitlist) is
+: Number of confirmed attendees before the [waitlist](waitlist.md) is
 activated. This should be below the venue maximum *with some margin*,
 as the number of attendees can "jump" with either multi-registrations
 or parallel registration processes by multiple users.
@@ -124,7 +124,7 @@ Welcome email contents
 : Contents of said welcome email
 
 Use tickets
-: Enable [tickets](tickets) and check-in. If this is enabled, then for
+: Enable [tickets](tickets.md) and check-in. If this is enabled, then for
 each user a ticket is generated and attached to the welcome
 email. This ticket is built from the `ticket.json` file in the
 template directory. Enabling tickets also enables the check-in
@@ -252,24 +252,24 @@ active, then [cards](skinning#cards) (small adapted images in SVG and
 PNG format) will be published for sessions and speakers.
 
 Check-in active
-: If the [check-in](tickets) system is active and attendees can be
+: If the [check-in](tickets.md) system is active and attendees can be
 checked in.
 
 Conference feedback open
 : If registered attendees of the conference can leave
-[feedback](feedback) on the full conference.
+[feedback](feedback.md) on the full conference.
 
 Session feedback open
 : If registered attendees of the conference can leave
-[feedback](feedback) on individual sessions.
+[feedback](feedback.md) on individual sessions.
 
 Skill levels
-: Should the [call for papers](callforpapers) ask for skill levels on
+: Should the [call for papers](callforpapers.md) ask for skill levels on
 all sessions, and should they be displayed on the schedule and session
 lists.
 
 Call for papers intro
-: Text shown on the [call for papers](callforpapers) page, above the
+: Text shown on the [call for papers](callforpapers.md) page, above the
 actual call for papers. Can contain HTML.
 
 Testers
@@ -280,27 +280,27 @@ registered users and not registered users.
 
 Talkvoters
 : List of users who can vote in the
-[call for papers](callforpapers). This can be both registered users
+[call for papers](callforpapers.md). This can be both registered users
 and not registered users.
 
 Staff
 : List of users who can register as staff using the special
-[registration type](registrations). This is typically users who have
+[registration type](registrations.md). This is typically users who have
 not registered when they are added, since they will later use the
 staff registration to become registered.
 
 Volunteers
 : List of registered users who participate in the
-[volunteer schedule](volunteers). This must be registered users.
+[volunteer schedule](volunteers.md). This must be registered users.
 
 Check-in processors
-: List of registered users who work with [checking in users](tickets)
+: List of registered users who work with [checking in users](tickets.md)
 on arrival. This must be registered users.
 
 Jinja templates enabled
 : Indicate if jinja templating is active for this conference. This can only
   be enabled if the *jinja directory* setting is enabled in the
-  [superuser settings](super_conference), but can then be independently
+  [superuser settings](super_conference.md), but can then be independently
   turned on and off by a non-superuser.
 
 Width of HTML schedule

--- a/docs/confreg/emails.md
+++ b/docs/confreg/emails.md
@@ -29,7 +29,7 @@ same criteria to see.
 
 From
 :  The *from* address of the email will always be the
-[main contact address](super_conference) for the conference.
+[main contact address](super_conference.md) for the conference.
 
 Registration classes
 :  Select the registration classes that the email should be delivered to,

--- a/docs/confreg/feedback.md
+++ b/docs/confreg/feedback.md
@@ -2,7 +2,7 @@
 
 The feedback systems consists of [session feedback](#session) and
 [conference feedback](#conference). They can be independently enabled
-in the [configuration](configuring), and some events will only use
+in the [configuration](configuring.md), and some events will only use
 some of them.
 
 ## Session feedback <a name="session"></a>

--- a/docs/confreg/index.md
+++ b/docs/confreg/index.md
@@ -13,54 +13,54 @@ work from here.
 
 ## Conferences
 * Quickstart
-    * [Step by step to create a conference](stepbystep)
+    * [Step by step to create a conference](stepbystep.md)
 * Basics
     * [Creating new conference](super_conference#new) (superusers only)
-    * [Configuring a conference](configuring)
-    * [Conference series](series)
-	* [News](news)
+    * [Configuring a conference](configuring.md)
+    * [Conference series](series.md)
+	* [News](news.md)
 * Call for papers and schedule
-    * [Call for papers](callforpapers)
-    * [Schedule](schedule)
+    * [Call for papers](callforpapers.md)
+    * [Schedule](schedule.md)
     * [Slides](callforpapers#slides)
 * Registrations
-    * [Registrations and registration types](registrations)
-    * [Tickets and check-in](tickets)
-    * [Vouchers and discount codes](vouchers)
-    * [Waitlist](waitlist)
-    * [Emails](emails)
-    * [Wiki pages](wiki)
-    * [Signups](signups)
-    * [Volunteers](volunteers)
-    * [Reports](reports)
+    * [Registrations and registration types](registrations.md)
+    * [Tickets and check-in](tickets.md)
+    * [Vouchers and discount codes](vouchers.md)
+    * [Waitlist](waitlist.md)
+    * [Emails](emails.md)
+    * [Wiki pages](wiki.md)
+    * [Signups](signups.md)
+    * [Volunteers](volunteers.md)
+    * [Reports](reports.md)
 * Feedback
-    * [Feedback](feedback)
+    * [Feedback](feedback.md)
 * Sponsors
-    * [Sponsors](sponsors)
+    * [Sponsors](sponsors.md)
 * Advanced
-    * [Access tokens](tokens)
-    * [Badges](badges)
-    * [Integrations](integrations)
+    * [Access tokens](tokens.md)
+    * [Badges](badges.md)
+    * [Integrations](integrations.md)
         * [Campaigns](integrations#campaigns)
-    * [Copying from another conference](copyfromother)
-    * [Skinning the conference pages](skinning)
-	* [Providing registration data](regprovider)
+    * [Copying from another conference](copyfromother.md)
+    * [Skinning the conference pages](skinning.md)
+	* [Providing registration data](regprovider.md)
 
 
 ## Membership
 
-* [Membership](membership)
-* [Meetings](meetings)
+* [Membership](membership.md)
+* [Meetings](meetings.md)
 
 ## Elections
 
-* [Elections](elections)
+* [Elections](elections.md)
 
 ## Global configuration
 
 * Invoices and payments
-    * [Payment methods](payment)
+    * [Payment methods](payment.md)
 * Scheduled jobs
-    * [Scheduled jobs](jobs)
+    * [Scheduled jobs](jobs.md)
 * Email infrastructure
-    * [Email infrastructure](mail)
+    * [Email infrastructure](mail.md)

--- a/docs/confreg/integrations.md
+++ b/docs/confreg/integrations.md
@@ -282,7 +282,7 @@ twitter account, thereby giving a conference series it's own twitter
 account, but having conferences in it share (by default).
 
 To use the Twitter integration, one must first set up twitter OAuth
-credentials. This is done by adding an [OAuth](oauth) application, after
+credentials. This is done by adding an [OAuth](oauth.md) application, after
 first registering a Twitter application in the Twitter systems.
 
 Once this is done, you can create the Messaging Provider record for
@@ -337,7 +337,7 @@ The Mastodon integration supports multiple different Mastodon
 instances, but will default to https://mastodon.social/.
 
 To use the Mastodon integration, one must first set up an [OAuth
-application](oauth). This happens in "Administration" - "OAuth".
+application](oauth.md). This happens in "Administration" - "OAuth".
 
 Once this is done, you can create the Messaging Provider record for
 each conference series. Other than the normal fields, there will be a

--- a/docs/confreg/news.md
+++ b/docs/confreg/news.md
@@ -6,7 +6,7 @@ announcements. It does not support paging or archiving.
 All news posts will syndicate to the main website frontpage. For each
 post showing up there will link back to the front page of the
 conference website (as defined in the
-[conference metadata](super_conference). Thus it makes sense for the
+[conference metadata](super_conference.md). Thus it makes sense for the
 news to be published there.
 
 In order to post a news, the user must have a News Poster Profile,

--- a/docs/confreg/oauth.md
+++ b/docs/confreg/oauth.md
@@ -1,7 +1,7 @@
 # OAuth
 
 OAuth is currently used for two different things in the system -- for
-integrating with [messaging systems](integrations) and for performing
+integrating with [messaging systems](integrations.md) and for performing
 login in case the postgresql.org community authentication system is
 not used.
 

--- a/docs/confreg/registrations.md
+++ b/docs/confreg/registrations.md
@@ -12,7 +12,7 @@ succeeds can always be discussed..):
    an account, or one can be created as part of the signup
    process.
 1. The exact fields to be filled out can be
-   [configured](configuring) at the conference level, for
+   [configured](configuring.md) at the conference level, for
    example if there should be a field about t-shirt size or not.
 1. The attendee can incrementally fill out and save in between if
    necessary. If they do that, they will at regular intervals receive
@@ -24,15 +24,15 @@ succeeds can always be discussed..):
 1. Once the invoice is generated, the registration data is
    locked. This invoice can then be paid by any of the configured
    payment methods, normally by credit card or PayPal. If the invoice
-   is not paid within the defined [autocancel](configuring) period,
+   is not paid within the defined [autocancel](configuring.md) period,
    the invoice is automatically canceled, and the registration is
    returned to unlocked state, and will again start receiving
    reminders to complete it.
 1. Once the invoice is paid, a receipt is sent to the user. If a
-   welcome email is [configured](configuring) for the conference, this
+   welcome email is [configured](configuring.md) for the conference, this
    email will be sent to the user.
 1. Certain fields are unlocked for editing again, until the *allow
-   editing* checkbox is [turned off](configuring). The registration is
+   editing* checkbox is [turned off](configuring.md). The registration is
    now fully complete.
 
 ![Regular registration workflow](graphs/regular_reg.svg)
@@ -48,7 +48,7 @@ registration for somebody else, the process is the same.
 1. For each of the attendees that should be registered, the email
    address is added and then the registration details are filled out
    for that attendee. Additional options can be added if necessary, as
-   well as [voucher and discount codes](vouchers). The same fields and
+   well as [voucher and discount codes](vouchers.md). The same fields and
    restrictions as regular registrations are used.
 1. Once all registrations have been made, the user picks *Create
    invoice*. At this point an invoice is created for all registrations
@@ -66,7 +66,7 @@ registration for somebody else, the process is the same.
       attendee can also create a new account at this point.
 
 The system for multiple payments is automatically disabled once the
-[waitlist](waitlist) is in force.
+[waitlist](waitlist.md) is in force.
 
 ## Registration types and classes <a name="typesandclasses"></a>
 
@@ -119,7 +119,7 @@ should be able to be substituted at the last moment.
 
 Confirmed staff
 : The attendee registering must use one of the accounts that
-are listed as staff in the [conference configuration](configuring).
+are listed as staff in the [conference configuration](configuring.md).
 
 ### Registration days <a name="days"></a>
 
@@ -129,7 +129,7 @@ used to limit certain registration types and additional options to certain days,
 typically used to render information on the badges or produce numbers to a venue.
 
 IN the system, registration days are simply a list of dates, that must fall
-between the [conference](configuring) start date and end date.
+between the [conference](configuring.md) start date and end date.
 
 ## Additional options <a name="options"></a>
 
@@ -137,7 +137,7 @@ Additional options represent things that can be added to a
 registration, such as training sessions, attendance to a separate
 event etc. An additional option can either be paid for, or it can be a
 free option. It is something that is normally done at registration
-time, and should not be confused with [signups](signups) which are
+time, and should not be confused with [signups](signups.md) which are
 normally used to handle things like signing up for a social event or a
 dinner or similar things.
 
@@ -168,7 +168,7 @@ To perform a registration transfer:
 
 1. Ensure the *new* person attending makes a registration in the
    system, but does *not* generate an invoice. If the
-   [waitlist](waitlist) is active, the registration should also *not*
+   [waitlist](waitlist.md) is active, the registration should also *not*
    be signed up on the waitlist (if it is, it has to be canceled
    first).
 2. Go to the transfer page, and pick the registrations to transfer to
@@ -228,7 +228,7 @@ requirements such as a student ID to access student discounts.
 
 Autocancel invoices
 : If registrations with this registration type should override the value for
-autocancel from the [conference](configuring). The lowest value of
+autocancel from the [conference](configuring.md). The lowest value of
 autocancel is always used.
 
 Requires option
@@ -277,7 +277,7 @@ completed.
 
 Autocancel invoices
 : If registrations with this option should override the value for
-autocancel from the [conference](configuring). The lowest value of
+autocancel from the [conference](configuring.md). The lowest value of
 autocancel is always used.
 
 Requires regtype

--- a/docs/confreg/regprovider.md
+++ b/docs/confreg/regprovider.md
@@ -14,7 +14,7 @@ The flow for getting the registration data is:
    an error message indicating so. If the registration is valid for
    the specified conference, the user is redirected back to the URL in
    the `redir` parameter (note! A list of allowed redirect URLs must
-   be provided in the [conference configuration](super_conference)). A
+   be provided in the [conference configuration](super_conference.md)). A
    temporary token valid for 5 minutes is generated, and appended to
    the redirection URL with the name `token`.
 1. The application intercepts this token, stores it somewhere

--- a/docs/confreg/schedule.md
+++ b/docs/confreg/schedule.md
@@ -2,7 +2,7 @@
 
 ## Scheduling
 
-Once talks have been accepted in the [call for papers](callforpapers),
+Once talks have been accepted in the [call for papers](callforpapers.md),
 or sessions have been manually added, scheduling takes place.
 
 The following terms are in use for scheduling:
@@ -65,7 +65,7 @@ making changes to the schedule after it has been published. If the
 changes look OK, hit the confirm link to publish.
 
 The published schedule will immediately become available *if* schedule
-publishing has been activated on the [conference](configuring).
+publishing has been activated on the [conference](configuring.md).
 
 ## PDF Schedules
 
@@ -103,7 +103,7 @@ Foreground color
 
 In call for papers
 :   Whether this track should be available to choose in the
-[call for papers](callforpapers) submission form.
+[call for papers](callforpapers.md) submission form.
 
 In session list
 :   Whether sessions in this track are included in the session list. This can
@@ -117,7 +117,7 @@ Show company
 Allow speaker reg
 :   Speakers with approved talks in this track will be allowed to
 register for free *if* a registration type with one of the
-[special registration types](registrations#typesandclasses) for speaker
+[special registration types](registrations.md#typesandclasses) for speaker
 registration exists.
 
 

--- a/docs/confreg/series.md
+++ b/docs/confreg/series.md
@@ -5,7 +5,7 @@ runs across multiple instances. For example, "PGConf.EU" is a series
 and "PGConf.EU 2018" is an instance.
 
 Conference series are primarily used for permissions, the
-[e-mail opt-out](emails#optout) functionality and for providing
+[e-mail opt-out](emails.md#optout) functionality and for providing
 introductory information on the main website.
 
 

--- a/docs/confreg/signups.md
+++ b/docs/confreg/signups.md
@@ -62,7 +62,7 @@ those of the permitted registration types) can sign up
 Using the send email functionality, it is possible to send an email to
 attendees for a signup. This is a one-time email that goes to their
 mailbox but is *not* visible on the registration page after the fact
-(unlike regular [attendee emails](emails)).
+(unlike regular [attendee emails](emails.md)).
 
 For each email a subject and a body can be specified (no formatting is
 done, so make sure to put reasonable linebreaks in place, and don't
@@ -75,7 +75,7 @@ sent to attendees with more than one response, the form has to be
 executed multiple time, once for each response.
 
 The emails will be sent from the main conference
-[contact address](super_conference).
+[contact address](super_conference.md).
 
 ## Results
 

--- a/docs/confreg/skinning.md
+++ b/docs/confreg/skinning.md
@@ -240,7 +240,7 @@ Unlike some other templates, the included SVG templates in the default
 system are *not* meant to be used for anything other than an
 example. They should always be overridden, and until that is done, card
 publishing should not be
-[enabled on the conference](configuring#conferenceform).
+[enabled on the conference](configuring.md#conferenceform).
 
 # Tickets and Badges <a name="badges"></a>
 
@@ -355,7 +355,7 @@ output format as `badge`.
 ## Tickets
 
 Tickets are automatically generated and emailed to users along with
-the welcome email as [configured](configuring).
+the welcome email as [configured](configuring.md).
 
 They can also be downloaded from the attendee registration dashboard,
 or be previewed from the administration view of an attendee. In both

--- a/docs/confreg/sponsors.md
+++ b/docs/confreg/sponsors.md
@@ -39,7 +39,7 @@ To set up sponsorship for a conference, in order:
 1. Upload a [sponsorship contract](#contract). Normally just one is
    needed, but if different ones are used then upload them separately.
 1. Create one or more [sponsorship levels](#level).
-1. Open sponsorship on [the conference](configuring).
+1. Open sponsorship on [the conference](configuring.md).
 
 Note that the *benefits* should **never** be changed after sponsors
 have started to sign up, but there is nothing in the system actually
@@ -175,7 +175,7 @@ Scanning of attendee badges
    in which case the sponsor will get an error when they try to scan
    their badge.
    Note that for this feature to work, the *Field: badge scanning*
-   on the [conference configuration](configuring) must be enabled.
+   on the [conference configuration](configuring.md) must be enabled.
 
 Submit session
 :  This benefit class allows the sponsor to submit a session for the

--- a/docs/confreg/stepbystep.md
+++ b/docs/confreg/stepbystep.md
@@ -3,31 +3,31 @@
 The following is not an exhaustive list, but hopefully enough to get
 off the ground.
 
-1. Create a new [conference](super_conference) (must be done by a
+1. Create a new [conference](super_conference.md) (must be done by a
    superuser).
-1. Configure all the metadata on the [conference](configuring).
+1. Configure all the metadata on the [conference](configuring.md).
 1. Set up call for papers
-    1. Add one or more [tracks](schedule#tracks), and decide if they
+    1. Add one or more [tracks](schedule.md#tracks), and decide if they
        should be included in the call for papers.
     1. Call for papers can now be opened
 1. Set up for registrations
-	1. Add one or more [registration days](registrations#days) that
+	1. Add one or more [registration days](registrations.md#days) that
        can be connected to the registration types.
     1. Add one or more
-       [registration classes](registrations#typesandclasses).
+       [registration classes](registrations.md#typesandclasses).
 	1. Add one or more
-       [registration types](registrations#typesandclasses).
+       [registration types](registrations.md#typesandclasses).
     1. If used, add one or more
-       [additional options](registrations#additionaloptions).
-    1. Decide if [tickets](tickets) and check-in should be used, and
+       [additional options](registrations.md#additionaloptions).
+    1. Decide if [tickets](tickets.md) and check-in should be used, and
        in this case create a template for tickets if a special design
        is needed.
     1. Registration can now be opened
 1. Set up schedule
     1. Wait for the call for papers to finish.
-	1. [Vote](callforpapers) on talks.
-	1. [Decide](callforpapers) on talks and
-       [notify speakers](callforpapers).
-	1. Add one or more [rooms](schedule#rooms).
-	1. Add one or more [schedule slots](schedule).
-	1. Create a tentative [schedule](schedule) and publish it.
+	1. [Vote](callforpapers.md) on talks.
+	1. [Decide](callforpapers.md) on talks and
+       [notify speakers](callforpapers.md).
+	1. Add one or more [rooms](schedule.md#rooms).
+	1. Add one or more [schedule slots](schedule.md).
+	1. Create a tentative [schedule](schedule.md) and publish it.

--- a/docs/confreg/super_conference.md
+++ b/docs/confreg/super_conference.md
@@ -3,7 +3,7 @@
 This documentation page covers how to edit the superuser only parameters
 for a conference, including [creating a new conference](#new). For
 information about how to edit the regular parameters for a conference, see
-the [separate page](configuring).
+the [separate page](configuring.md).
 
 ## Creating a new conference
 
@@ -102,7 +102,7 @@ but it does include the invoices that sponsors will get if they for
 example buy extra vouchers.
 
 Allowed web origins for API calls
-:  A list of allowed web origins for making [API calls](regprovider).
+:  A list of allowed web origins for making [API calls](regprovider.md).
 This will be used both for validating a redirect URL and for
 controlling what must be in the Origin header when making an API
 call to get the JWT token.

--- a/docs/confreg/tickets.md
+++ b/docs/confreg/tickets.md
@@ -11,7 +11,7 @@ ticketing.
 ## Tickets
 
 If nothing else is defined a very basic ticket is generated. In almost
-every case, the tickets should be [skinned](skinning) using the
+every case, the tickets should be [skinned](skinning.md) using the
 `ticket.json` file.
 
 Tickets will be attached to the conference *welcome email*, and also
@@ -113,7 +113,7 @@ fully safe.
 ### Enabling the check-in app
 
 The check-in app is disabled by default, and needs to be enabled with
-a checkbox on the [configuration page](configuring). The app itself
+a checkbox on the [configuration page](configuring.md). The app itself
 will function even when the system is disabled, but it will be unable
 to get or modify any information.
 

--- a/docs/confreg/volunteers.md
+++ b/docs/confreg/volunteers.md
@@ -5,7 +5,7 @@ The volunteer schedule system ties together attendees with
 
 To begin, create the slots as needed in the administrative interface,
 and assign the volunteers using the
-[conference configuration](configuring). Volunteers can also be added
+[conference configuration](configuring.md). Volunteers can also be added
 later on, in which case they will just have to sign up for what's
 left.
 

--- a/docs/confreg/vouchers.md
+++ b/docs/confreg/vouchers.md
@@ -14,7 +14,7 @@ puts this secret key in the voucher field, which makes the
 registration free.
 
 If all that's wanted is to register for another user, it's better to
-use the [advanced registration flow](registrations). Vouchers are
+use the [advanced registration flow](registrations.md). Vouchers are
 appropriate if the vouchers are distributed to a different
 organisation, and where the person paying does not have access to the
 information about the attendee.
@@ -63,7 +63,7 @@ same time as discount percentage.
 
 Public
 :  If this discount code is public. If a code is made public it becomes
-available using a separate permission in the [access tokens](tokens)
+available using a separate permission in the [access tokens](tokens.md)
 feature, and can that way be used to for example update a website. For
 codes that need to remain secret for their use, obviously public
 should not be set as it could be leaked through the token interface.

--- a/docs/confreg/waitlist.md
+++ b/docs/confreg/waitlist.md
@@ -2,7 +2,7 @@
 
 The waitlist is enabled automatically when the number of *confirmed*
 attendees to the conference exceeds the number of attendees
-[configured](configuring) for it. There is no way to manually enable
+[configured](configuring.md) for it. There is no way to manually enable
 the waitlist, other than to reduce the number of attendees before
 waitlist to a number below the current amount.
 
@@ -67,7 +67,7 @@ It is also possible to send email to all attendees on the
 waitlist. This can be filtered to be all on waitlist, or just the ones
 with or without offers.
 
-Unlike [attendee emails](emails) these are sent directly but are not
+Unlike [attendee emails](emails.md) these are sent directly but are not
 archived on the registration pages or similar, as these are to
 accounts that have not yet got a registration.
 


### PR DESCRIPTION
There are links in the documentation (`docs/`) that are supposed to point/redirect to some other `.md` files, but currently, clicking those links gives the error **404**.

**Reason:** Incorrect paths.

**Example:**
[https://github.com/pgeu/pgeu-system/blob/master/docs/confreg/index.md](https://github.com/pgeu/pgeu-system/blob/master/docs/confreg/index.md)
On this page, none of the links is accessible.