### PR TITLE
Improve wording on admin signup notification

### DIFF
--- a/template.jinja/confwiki/mail/admin_notify_signup.txt
+++ b/template.jinja/confwiki/mail/admin_notify_signup.txt
@@ -1,4 +1,4 @@
-Attendee {{attendeesignup.attendee.fullname}} has signed up for {{signup.title}}.
+Attendee {{attendeesignup.attendee.fullname}} has responded to signup {{signup.title}}.
 
 Attendee name:     {{attendeesignup.attendee.fullname}}
 Registration type: {{attendeesignup.attendee.regtype.regtype}}


### PR DESCRIPTION
The text was slightly unclear, as it announced an attendee having signed up even in the cases where the attendee had chosen to not do so.

Given that the value of 'attendeesignup.choice' is a free text and not encoded in the system, the text can not be controlled. A generic phrase was chosen instead.