### PR TITLE
Update speakerprofile.html

### DIFF
--- a/template.jinja/confreg/speakerprofile.html
+++ b/template.jinja/confreg/speakerprofile.html
@@ -41,7 +41,7 @@ The following conferences currently have open call for papers:
 {%endif%}
 
 {%if conferences%}
-<h2>Previous conferences</h2>
+<h2>List of talks subimtted</h2>
 <p>
 You have submitted talks to the following conferences:
 <ul>


### PR DESCRIPTION
Since I saw this page multiple times without noticing that the section "Previous Conferences" wasn't actually listing the conferences I attended *but* the talks I submitted, while I was searching for it, I propose a change in the title to make it more "visible", I assume I'm not the only one having troubles here :-) -- or maybe I am, I'm aging :-)