### PR TITLE
Set a default background color on tracks

### DIFF
--- a/postgresqleu/confreg/models.py
+++ b/postgresqleu/confreg/models.py
@@ -925,7 +925,7 @@ class RegistrationTransferPending(models.Model):
 class Track(models.Model):
     conference = models.ForeignKey(Conference, null=False, blank=False, on_delete=models.CASCADE)
     trackname = models.CharField(max_length=100, null=False, blank=False, verbose_name="Track name")
-    color = models.CharField(max_length=20, null=False, blank=True, validators=[color_validator, ], verbose_name="Background color")
+    color = models.CharField(max_length=20, null=False, blank=True, validators=[color_validator, ], verbose_name="Background color", default='#ffffff')
     fgcolor = models.CharField(max_length=20, null=False, blank=False, validators=[color_validator, ], verbose_name="Foreground color", default='#000000')
     sortkey = models.IntegerField(null=False, default=100, blank=False)
     incfp = models.BooleanField(null=False, default=False, blank=False, verbose_name="In call for papers")


### PR DESCRIPTION
If the user doesn't specify a background color when configuring a track then the generated CSS is incorrect:
```css
  .track-xyz {
    background-color: ;
    color: #000000;
  }
```

This adds a default color which is the inverse of the default text color to avoid incorrect CSS.