### PR TITLE
Allow loading settings from outside of the postgresqleu tree

### DIFF
--- a/postgresqleu/settings.py
+++ b/postgresqleu/settings.py
@@ -303,11 +303,24 @@ MEETINGS_WS_BASE_URL = None
 # be used instead of TCP.
 MEETINGS_STATUS_BASE_URL = None
 
-# If there is a local_settings.py, let it override our settings
+# First, attempt to load settings from a pgeu_system_settings module
+# available somewhere in the PYTHONPATH.
+try:
+    from pgeu_system_global_settings import *
+except ImportError as e:
+    pass
+# Next, give the local_settings.py from the postgresqleu tree a chance
+# to provide configuration.
 try:
     from .local_settings import *
 except ImportError as e:
-    pass
+    # If there's no local_settings.py within the postgresqleu tree, check
+    # for a globally available pgeu_system_settings module in any configured
+    # PYTHONPATH.
+    try:
+        from pgeu_system_settings import *
+    except ImportError as e:
+        pass
 
 PRELOAD_URLS = []
 if 'SYSTEM_SKIN_DIRECTORY' in globals():
@@ -334,6 +347,12 @@ if 'SYSTEM_SKIN_DIRECTORY' in globals():
 else:
     HAS_SKIN = False
 
+# Try to load overrides from PYTHONPATH. This allows overriding skin
+# settings for testing purposes.
+try:
+    from pgeu_system_override_settings import *
+except ImportError as e:
+    pass
 
 if not SECRET_KEY:
     raise Exception("SECRET_KEY must be configured!")

--- a/tools/devsetup/README.txt
+++ b/tools/devsetup/README.txt
@@ -1,3 +1,24 @@
+Configuration
+-------------
+
+The traditional approach is to create a local_settings.py file under
+the postgresqleu directory, a template is provided.
+
+To allow out-of-module configuration, it is possible to instead
+provide a python module pgeu_system_global_settings and extend
+PYTHONPATH for it to be detected. Settings in there are loaded first,
+in case the above mentioned local_settings.py is available, too, it
+will override global settings.
+
+The skin usually provides skin_settings.py and allows customization
+through a similar skin_local_settings.py. These again take precedence
+over global settings.
+
+Last, a global python module pgeu_system_override_settings is
+attempted to be loaded. It allows overriding any settings of the
+pgeu-system or the skin.
+
+
 Dependencies needed before running
 ----------------------------------
 

--- a/tools/devsetup/dev_setup.sh
+++ b/tools/devsetup/dev_setup.sh
@@ -33,6 +33,10 @@ EOF
 chmod +x ../../python
 ../../python -m pip install -r dev_requirements.txt
 
+# Configure the test instance. This is done through the traditional
+# approach with local_settings.py here. An alternative would be to
+# write the very same content to
+# venv_dev/lib/python3.11/site-packages/pgeu_system_global_settings.py
 cd ../..
 cat > postgresqleu/local_settings.py <<EOF
 DEBUG=True


### PR DESCRIPTION
To ease building docker images and prevent having to maintain an
in-tree file for local settings, allow a pgeu_system_settings
module anywhere in the PYTHONPATH for configuration.
    
In addition, also allow overrides to be applied after loading the
skin.