### PR TITLE
Fix bug in calculation of circle location

### DIFF
--- a/postgresqleu/confreg/jinjapdf.py
+++ b/postgresqleu/confreg/jinjapdf.py
@@ -86,7 +86,7 @@ class JinjaFlowable(Flowable):
             else:
                 self.canv.setStrokeColor(get_color(o['stroke']))
         self.canv.circle(getmm(o, 'x'),
-                         self.height - getmm(o, 'y') - (getmm(o, 'radius') / 2),
+                         self.height - getmm(o, 'y') - getmm(o, 'radius'),
                          getmm(o, 'radius'),
                          stroke=stroke,
                          fill=fill)


### PR DESCRIPTION
The existing code to render a badge draws a circle at the specified `y` location + half the radius. From the user's perspective, this means that the `y` value specified in a `circle` is actually the chord through the circle located halfway between the topmost point and the center.

This is really difficult to use. The `y` value should correspond to either (1) the line tangent to the topmost point of the circle or (2) the horizontal diameter line of the circle.

This PR changes the `y` value to mean (1).