### PR TITLE
Include feedback URL QR code on the callforpapers page

### DIFF
--- a/postgresqleu/confreg/views.py
+++ b/postgresqleu/confreg/views.py
@@ -1949,6 +1949,7 @@ def callforpapers_edit(request, confname, sessionid):
             'slidesurlform': slidesurlform,
             'slidesfileform': slidesfileform,
             'slides': ConferenceSessionSlides.objects.filter(session=session),
+            'feedbackqrcode': generate_base64_qr('{0}/events/{1}/feedback/{2}'.format(settings.SITEBASE, confname, session.id), None, 300),
             })
 
     if session.id:

--- a/template.jinja/confreg/session_feedback.html
+++ b/template.jinja/confreg/session_feedback.html
@@ -50,8 +50,15 @@
 <input type="submit" name="submit" value="Upload slides">
 </form>
 
-{%if feedbackcount%}
 <h2>Feedback</h2>
+<h3>Feedback link</h3>
+<p>
+Attendees will be able to leave <a href="/events/{{conference.urlname}}/feedback/{{session.id}}">feedback</a> on your talk.
+This link will work once your talk has started.  You can include the below QR code in your slides to increase the response rate.
+</p>
+<p class="feedbak-qrcode"><img src="data:image/png;base64,{{ feedbackqrcode }}"></p>
+
+{%if feedbackcount%}
 {%if conference.feedbackopen%}
 <h3>Preliminary feedback!</h3>
 <p>


### PR DESCRIPTION
This makes it easy for speakers to include the feedback QR code in their slides

Fixes https://github.com/pgeu/pgeu-system/issues/188