### PR TITLE
Add visa letter request feature

### DIFF
--- a/postgresqleu/confreg/backendforms.py
+++ b/postgresqleu/confreg/backendforms.py
@@ -40,6 +40,7 @@ from postgresqleu.confsponsor.benefitclasses import get_benefit_id
 from postgresqleu.confreg.models import Conference, ConferenceRegistration, ConferenceAdditionalOption
 from postgresqleu.confreg.models import RegistrationClass, RegistrationType, RegistrationDay
 from postgresqleu.confreg.models import ConferenceFeedbackQuestion, Speaker
+from postgresqleu.confreg.models import VisaLetterRequest
 from postgresqleu.confreg.models import ConferenceSession, Track, Room, ConferenceSessionTag
 from postgresqleu.confreg.models import ConferenceSessionSlides
 from postgresqleu.confreg.models import ConferenceSessionScheduleSlot, VolunteerSlot
@@ -93,7 +94,8 @@ class BackendConferenceForm(BackendForm):
                   'callforpapersmaxsubmissions', 'skill_levels', 'showvotes', 'scoring_method', 'callforpaperstags', 'callforpapersrecording', 'sendwelcomemail',
                   'tickets', 'confirmpolicy', 'queuepartitioning', 'invoice_autocancel_hours', 'attendees_before_waitlist',
                   'transfer_cost', 'initial_common_countries', 'jinjaenabled', 'dynafields', 'scannerfields',
-                  'videoproviders', ]
+                  'videoproviders',
+                  'visa_letter_enabled', 'visa_letter_city', 'visa_letter_country', 'visa_letter_signer', ]
 
     def fix_fields(self):
         self.selectize_multiple_fields['volunteers'] = RegisteredUsersLookup(self.conference)
@@ -112,6 +114,7 @@ class BackendConferenceForm(BackendForm):
         {'id': 'callforpapers', 'legend': 'Call for papers', 'fields': ['callforpapersmaxsubmissions', 'skill_levels', 'callforpaperstags', 'callforpapersrecording', 'showvotes', 'scoring_method']},
         {'id': 'roles', 'legend': 'Roles', 'fields': ['testers', 'talkvoters', 'staff', 'volunteers', 'checkinprocessors', ]},
         {'id': 'display', 'legend': 'Display', 'fields': ['jinjaenabled', 'videoproviders', ]},
+        {'id': 'visaletters', 'legend': 'Visa letters', 'fields': ['visa_letter_enabled', 'visa_letter_city', 'visa_letter_country', 'visa_letter_signer', ]},
         {'id': 'legacy', 'legend': 'Legacy', 'fields': ['schedulewidth', 'pixelsperminute']},
     ]
 
@@ -2027,3 +2030,59 @@ class BackendRegistrationDmForm(django.forms.Form):
         if maxlength:
             self.fields['message'].max_length = maxlength
             self.fields['message'].help_text = 'Maximum message length for this provider is {} characters.'.format(maxlength)
+
+
+class BackendVisaLetterRequestForm(BackendForm):
+    helplink = "visaletters"
+    list_fields = ['registration', 'status', 'created_at']
+    readonly_fields = [
+        'passport_name', 'date_of_birth', 'passport_number', 'nationality', 'home_address',
+        'embassy_name', 'embassy_address',
+        'entry_date', 'exit_date', 'accommodation', 'contact_info',
+    ]
+    exclude_date_validators = ['date_of_birth', 'entry_date', 'exit_date']
+    queryset_select_related = ['registration']
+
+    class Meta:
+        model = VisaLetterRequest
+        fields = [
+            'registration',
+            'passport_name', 'passport_sex', 'date_of_birth', 'passport_number', 'nationality', 'home_address',
+            'embassy_name', 'embassy_address',
+            'entry_date', 'exit_date', 'accommodation', 'contact_info',
+            'status', 'admin_notes', 'accommodation_covered',
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['registration'].disabled = True
+        self.fields['passport_sex'].disabled = True
+        if self.instance.pk and self.instance.status == VisaLetterRequest.STATUS_APPROVED:
+            self.extrabuttons = list(self.extrabuttons) + [('Generate PDF', 'generate/')]
+            self.formnote = (
+                '<dialog id="visa-pdf-dialog" style="max-width:32em;padding:1.5em;border:1px solid #888;">'
+                '<h4>Generate visa letter PDF</h4>'
+                '<p><b>The signature image is NOT saved on the server.</b> '
+                'It is held in memory only long enough to render the PDF and is then discarded. '
+                'You must upload it every time you generate a PDF for any attendee.</p>'
+                '<p><label>Signature image (PNG or JPEG, &le; 2&nbsp;MB):<br>'
+                '<input type="file" name="signature" accept="image/png,image/jpeg" required></label></p>'
+                '<p style="text-align:right;">'
+                '<button type="button" onclick="this.closest(\'dialog\').close()">Cancel</button> '
+                '<button type="submit" formaction="generate/" formenctype="multipart/form-data" formnovalidate>Generate PDF</button>'
+                '</p>'
+                '</dialog>'
+                '<script>'
+                'document.addEventListener("DOMContentLoaded",function(){'
+                'var d=document.getElementById("visa-pdf-dialog");if(!d)return;'
+                'document.querySelectorAll("a.btn").forEach(function(a){'
+                'if((a.getAttribute("href")||"").endsWith("generate/")){'
+                'a.addEventListener("click",function(e){e.preventDefault();d.showModal();});}});});'
+                '</script>'
+            )
+
+    def save(self, commit=True):
+        if self.instance.pk and 'status' in self.changed_data:
+            self.instance.reviewed_by = self.request.user
+            self.instance.reviewed_at = timezone.now()
+        return super().save(commit=commit)

--- a/postgresqleu/confreg/backendviews.py
+++ b/postgresqleu/confreg/backendviews.py
@@ -36,6 +36,7 @@ from .models import ShirtSize
 from .models import PendingAdditionalOrder
 from .models import ConferenceTweetQueue
 from .models import MessagingProvider
+from .models import VisaLetterRequest
 from .models import RefundPattern
 
 from postgresqleu.invoices.models import Invoice
@@ -51,6 +52,7 @@ from .backendforms import BackendTrackForm, BackendRoomForm, BackendConferenceSe
 from .backendforms import BackendConferenceSpeakerForm, BackendGlobalSpeakerForm, BackendTagForm
 from .backendforms import BackendConferenceSessionSlotForm, BackendVolunteerSlotForm
 from .backendforms import BackendFeedbackQuestionForm, BackendDiscountCodeForm
+from .backendforms import BackendVisaLetterRequestForm
 from .backendforms import BackendAccessTokenForm
 from .backendforms import BackendConferenceSeriesForm
 from .backendforms import BackendTshirtSizeForm
@@ -267,6 +269,15 @@ def edit_feedbackquestions(request, urlname, rest):
                                urlname,
                                BackendFeedbackQuestionForm,
                                rest)
+
+
+def edit_visaletters(request, urlname, rest):
+    return backend_list_editor(request,
+                               urlname,
+                               BackendVisaLetterRequestForm,
+                               rest,
+                               allow_new=False,
+                               allow_delete=True)
 
 
 def edit_discountcodes(request, urlname, rest):
@@ -729,6 +740,7 @@ def purge_personal_data(request, urlname):
         exec_no_result("INSERT INTO confreg_aggregateddietary (conference_id, dietary, num) SELECT conference_id, lower(dietary), count(*) FROM confreg_conferenceregistration WHERE conference_id=%(confid)s AND dietary IS NOT NULL AND dietary != '' GROUP BY conference_id, lower(dietary)", {'confid': conference.id, })
         exec_no_result("INSERT INTO confreg_aggregatepronouns (conference_id, pronouns, num) SELECT conference_id, pronouns, count(*) FROM confreg_conferenceregistration WHERE conference_id=%(confid)s GROUP BY conference_id, pronouns", {'confid': conference.id, })
         exec_no_result("UPDATE confreg_conferenceregistration SET shirtsize_id=NULL, dietary='', phone='', address='', pronouns=0 WHERE conference_id=%(confid)s", {'confid': conference.id, })
+        VisaLetterRequest.objects.filter(conference=conference).delete()
         conference.personal_data_purged = timezone.now()
         conference.save()
         messages.info(request, "Personal data purged from conference")

--- a/postgresqleu/confreg/migrations/0126_visaletter.py
+++ b/postgresqleu/confreg/migrations/0126_visaletter.py
@@ -1,0 +1,66 @@
+# Generated for the visa letter feature.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('confreg', '0125_index_conference_enddate'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='conference',
+            name='visa_letter_enabled',
+            field=models.BooleanField(default=False, help_text='Allow eligible attendees to request a visa invitation letter', verbose_name='Visa letters'),
+        ),
+        migrations.AddField(
+            model_name='conference',
+            name='visa_letter_city',
+            field=models.CharField(blank=True, help_text='City the conference is held in, as it should appear in the visa letter (e.g. "Berlin")', max_length=100, verbose_name='Visa letter city'),
+        ),
+        migrations.AddField(
+            model_name='conference',
+            name='visa_letter_country',
+            field=models.CharField(blank=True, help_text='Country the conference is held in, as it should appear in the visa letter (e.g. "Germany")', max_length=100, verbose_name='Visa letter country'),
+        ),
+        migrations.AddField(
+            model_name='conference',
+            name='visa_letter_signer',
+            field=models.TextField(blank=True, help_text='Multi-line text printed below the signature image: name, title, address, phone, email', verbose_name='Visa letter signer'),
+        ),
+        migrations.CreateModel(
+            name='VisaLetterRequest',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('status', models.CharField(choices=[('pending', 'Pending review'), ('changes_needed', 'Changes needed'), ('approved', 'Approved'), ('rejected', 'Rejected')], default='pending', max_length=20)),
+                ('reviewed_at', models.DateTimeField(blank=True, null=True)),
+                ('admin_notes', models.TextField(blank=True, default='', verbose_name='Admin notes')),
+                ('accommodation_covered', models.BooleanField(default=False, help_text='Tick if accommodation and travel costs are covered for this attendee; the visa letter will state this.', verbose_name='Accommodation and travel covered')),
+                ('passport_name', models.CharField(max_length=200, verbose_name='Full name on passport')),
+                ('passport_sex', models.CharField(choices=[('male', 'Male'), ('female', 'Female')], max_length=10, verbose_name='Sex (as on passport)')),
+                ('date_of_birth', models.DateField(verbose_name='Date of birth')),
+                ('passport_number', models.CharField(max_length=50, verbose_name='Passport number')),
+                ('nationality', models.CharField(max_length=100, verbose_name='Nationality')),
+                ('home_address', models.TextField(verbose_name='Home address')),
+                ('embassy_name', models.CharField(max_length=200, verbose_name='Embassy / consulate name')),
+                ('embassy_address', models.TextField(verbose_name='Embassy / consulate address')),
+                ('entry_date', models.DateField(verbose_name='Planned entry date')),
+                ('exit_date', models.DateField(verbose_name='Planned exit date')),
+                ('accommodation', models.CharField(max_length=200, verbose_name='Accommodation while in country')),
+                ('contact_info', models.CharField(max_length=200, verbose_name='Contact info while in country')),
+                ('conference', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='confreg.conference')),
+                ('registration', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='confreg.conferenceregistration')),
+                ('reviewed_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'ordering': ('-created_at',),
+                'unique_together': {('conference', 'registration')},
+            },
+        ),
+    ]

--- a/postgresqleu/confreg/models.py
+++ b/postgresqleu/confreg/models.py
@@ -255,6 +255,11 @@ class Conference(models.Model):
     key_private = models.TextField(null=False, blank=True, verbose_name="Private RSA key for signatures")
     web_origins = models.CharField(null=False, blank=True, max_length=1000, verbose_name="Allowed web origins for API calls (comma separated list)")
 
+    visa_letter_enabled = models.BooleanField(blank=False, null=False, default=False, verbose_name="Visa letters", help_text="Allow eligible attendees to request a visa invitation letter")
+    visa_letter_city = models.CharField(max_length=100, blank=True, null=False, verbose_name="Visa letter city", help_text="City the conference is held in, as it should appear in the visa letter (e.g. \"Berlin\")")
+    visa_letter_country = models.CharField(max_length=100, blank=True, null=False, verbose_name="Visa letter country", help_text="Country the conference is held in, as it should appear in the visa letter (e.g. \"Germany\")")
+    visa_letter_signer = models.TextField(blank=True, null=False, verbose_name="Visa letter signer", help_text="Multi-line text printed below the signature image: name, title, address, phone, email")
+
     # Attributes that are safe to access in jinja templates
     _safe_attributes = ('registrationopen', 'registrationtimerange', 'IsRegistrationOpen',
                         'startdate', 'enddate',
@@ -265,7 +270,7 @@ class Conference(models.Model):
                         'confirmpolicy', 'conferencedatestr', 'location',
                         'feedbackopen', 'skill_levels', 'urlname', 'conferencename',
                         'series', 'sendwelcomemail', 'scannerfields_list',
-                        'vat_registrations',
+                        'vat_registrations', 'visa_letter_enabled',
     )
 
     def safe_export(self):
@@ -1963,3 +1968,76 @@ class ConferenceRemovedData(models.Model):
             ('urlname', 'description'),
         )
         ordering = ('urlname', 'description')
+
+
+class AttendeeSubmission(models.Model):
+    """Abstract base for per-registration form submissions tied to a conference.
+
+    Concrete subclasses add their own data fields and override purge_personal_data()
+    to either delete the row or null out personal fields, depending on whether any
+    aggregate (e.g. anonymised survey responses) should survive a personal-data purge.
+    """
+    conference = models.ForeignKey(Conference, on_delete=models.CASCADE)
+    registration = models.ForeignKey(ConferenceRegistration, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+        ordering = ('-created_at', )
+
+    def purge_personal_data(self):
+        raise NotImplementedError
+
+
+class VisaLetterRequest(AttendeeSubmission):
+    STATUS_PENDING = 'pending'
+    STATUS_CHANGES_NEEDED = 'changes_needed'
+    STATUS_APPROVED = 'approved'
+    STATUS_REJECTED = 'rejected'
+    STATUS_CHOICES = (
+        (STATUS_PENDING, 'Pending review'),
+        (STATUS_CHANGES_NEEDED, 'Changes needed'),
+        (STATUS_APPROVED, 'Approved'),
+        (STATUS_REJECTED, 'Rejected'),
+    )
+
+    SEX_CHOICES = (
+        ('male', 'Male'),
+        ('female', 'Female'),
+    )
+
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_PENDING)
+    reviewed_at = models.DateTimeField(null=True, blank=True)
+    reviewed_by = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL, related_name='+')
+    admin_notes = models.TextField(blank=True, null=False, default='', verbose_name="Admin notes")
+    accommodation_covered = models.BooleanField(blank=False, null=False, default=False, verbose_name="Accommodation and travel covered", help_text="Tick if accommodation and travel costs are covered for this attendee; the visa letter will state this.")
+
+    passport_name = models.CharField(max_length=200, verbose_name="Full name on passport")
+    passport_sex = models.CharField(max_length=10, choices=SEX_CHOICES, verbose_name="Sex (as on passport)")
+    date_of_birth = models.DateField(verbose_name="Date of birth")
+    passport_number = models.CharField(max_length=50, verbose_name="Passport number")
+    nationality = models.CharField(max_length=100, verbose_name="Nationality")
+    home_address = models.TextField(verbose_name="Home address")
+    embassy_name = models.CharField(max_length=200, verbose_name="Embassy / consulate name")
+    embassy_address = models.TextField(verbose_name="Embassy / consulate address")
+    entry_date = models.DateField(verbose_name="Planned entry date")
+    exit_date = models.DateField(verbose_name="Planned exit date")
+    accommodation = models.CharField(max_length=200, verbose_name="Accommodation while in country")
+    contact_info = models.CharField(max_length=200, verbose_name="Contact info while in country")
+
+    class Meta(AttendeeSubmission.Meta):
+        unique_together = (('conference', 'registration'), )
+
+    def __str__(self):
+        return '{} ({})'.format(self.registration.fullname, self.get_status_display())
+
+    def _display_registration(self, cache):
+        return self.registration.fullname
+
+    def clean(self):
+        super().clean()
+        if self.entry_date and self.exit_date and self.exit_date <= self.entry_date:
+            raise ValidationError({'exit_date': 'Exit date must be after entry date.'})
+
+    def purge_personal_data(self):
+        self.delete()

--- a/postgresqleu/confreg/views.py
+++ b/postgresqleu/confreg/views.py
@@ -3623,6 +3623,7 @@ def admin_dashboard_single(request, urlname):
             'pending_tweets': ConferenceTweetQueue.objects.filter(conference=conference, sent=False).exists(),
             'pending_tweet_approvals': ConferenceTweetQueue.objects.filter(conference=conference, approved=False).exists(),
             'pending_cancel_requests': ConferenceRegistration.objects.filter(conference=conference, cancelrequestedat__isnull=False, canceledat__isnull=True),
+            'pending_visa_requests': conditional_exec_to_scalar(conference.visa_letter_enabled, "SELECT EXISTS (SELECT 1 FROM confreg_visaletterrequest WHERE conference_id=%(confid)s AND status='pending')", {'confid': conference.id}),
         })
 
 

--- a/postgresqleu/confreg/visa.py
+++ b/postgresqleu/confreg/visa.py
@@ -36,10 +36,10 @@ def _is_speaker(registration):
 
 def is_visa_eligible(registration):
     return (
-        registration.payconfirmedat is not None
-        or registration.is_volunteer
-        or (registration.regtype and registration.regtype.specialtype in ('staff', 'spk', 'spkr'))
-        or _is_speaker(registration)
+        registration.payconfirmedat is not None or
+        registration.is_volunteer or
+        (registration.regtype and registration.regtype.specialtype in ('staff', 'spk', 'spkr')) or
+        _is_speaker(registration)
     )
 
 

--- a/postgresqleu/confreg/visa.py
+++ b/postgresqleu/confreg/visa.py
@@ -1,0 +1,260 @@
+import os
+from io import BytesIO
+from datetime import datetime
+
+from django import forms
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import Http404, HttpResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.utils.html import escape
+
+import jinja2
+
+from reportlab.lib.enums import TA_RIGHT
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import Image, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+from postgresqleu.util.image import rescale_image_bytes
+
+from .models import Conference, ConferenceRegistration, VisaLetterRequest
+from .util import get_authenticated_conference, render_conference_response
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+VISA_LETTER_TEMPLATE_PATH = os.path.join(PROJECT_ROOT, 'template', 'confreg', 'visa_letter_template.j2')
+
+
+def _is_speaker(registration):
+    return registration.conference.conferencesession_set.filter(
+        speaker__user=registration.attendee, status__in=[1, 4]).exists()
+
+
+def is_visa_eligible(registration):
+    return (
+        registration.payconfirmedat is not None
+        or registration.is_volunteer
+        or (registration.regtype and registration.regtype.specialtype in ('staff', 'spk', 'spkr'))
+        or _is_speaker(registration)
+    )
+
+
+class VisaLetterRequestForm(forms.ModelForm):
+    class Meta:
+        model = VisaLetterRequest
+        fields = [
+            'passport_name', 'passport_sex', 'date_of_birth', 'passport_number', 'nationality',
+            'home_address', 'embassy_name', 'embassy_address',
+            'entry_date', 'exit_date', 'accommodation', 'contact_info',
+        ]
+        widgets = {
+            'date_of_birth': forms.DateInput(attrs={'type': 'date'}),
+            'entry_date': forms.DateInput(attrs={'type': 'date'}),
+            'exit_date': forms.DateInput(attrs={'type': 'date'}),
+            'passport_name': forms.TextInput(attrs={'size': 60}),
+            'embassy_name': forms.TextInput(attrs={'size': 60}),
+            'accommodation': forms.TextInput(attrs={'size': 60}),
+            'contact_info': forms.TextInput(attrs={'size': 60}),
+        }
+
+    def clean(self):
+        cleaned = super().clean()
+        conf = self.instance.conference
+        entry = cleaned.get('entry_date')
+        exit_ = cleaned.get('exit_date')
+        if entry:
+            if entry > conf.enddate:
+                self.add_error('entry_date', 'Entry date must be before or during the conference.')
+            elif conf.startdate.toordinal() - entry.toordinal() > 30:
+                self.add_error('entry_date', 'Entry date must not be more than a month before the conference starts.')
+        if exit_:
+            if exit_ < conf.startdate:
+                self.add_error('exit_date', 'Exit date must be during or after the conference.')
+            elif exit_.toordinal() - conf.enddate.toordinal() > 30:
+                self.add_error('exit_date', 'Exit date must not be more than a month after the conference ends.')
+        return cleaned
+
+
+@login_required
+@transaction.atomic
+def visa_letter(request, confname):
+    conference = get_object_or_404(Conference, urlname=confname)
+    if not conference.visa_letter_enabled:
+        raise Http404
+    try:
+        registration = ConferenceRegistration.objects.get(
+            conference=conference, attendee=request.user, canceledat__isnull=True)
+    except ConferenceRegistration.DoesNotExist:
+        messages.error(request, "You must have a registration for this conference to request a visa letter.")
+        return redirect('/events/{}/'.format(confname))
+    if not is_visa_eligible(registration):
+        messages.error(request, "Visa letters are available to attendees with full payment confirmed, speakers, volunteers, and conference staff.")
+        return redirect('/events/{}/'.format(confname))
+
+    visa_request = VisaLetterRequest.objects.filter(
+        conference=conference, registration=registration).first()
+    editable = visa_request is None or visa_request.status == VisaLetterRequest.STATUS_CHANGES_NEEDED
+    form = None
+    if editable:
+        instance = visa_request or VisaLetterRequest(conference=conference, registration=registration)
+        if request.method == 'POST':
+            form = VisaLetterRequestForm(request.POST, instance=instance)
+            if form.is_valid():
+                obj = form.save(commit=False)
+                if visa_request is not None:
+                    obj.status = VisaLetterRequest.STATUS_PENDING
+                obj.save()
+                messages.success(request, "Your visa letter request has been submitted for review.")
+                return redirect('.')
+        else:
+            form = VisaLetterRequestForm(instance=instance)
+
+    return render_conference_response(request, conference, 'reg', 'confreg/visa_letter.html', {
+        'form': form,
+        'visa_request': visa_request,
+    })
+
+
+def admin_visa_letter_generate(request, urlname, requestid):
+    conference = get_authenticated_conference(request, urlname)
+    visa_request = get_object_or_404(
+        VisaLetterRequest,
+        id=requestid,
+        conference=conference,
+        status=VisaLetterRequest.STATUS_APPROVED,
+    )
+    if request.method != 'POST':
+        return redirect('../')
+
+    sig = request.FILES.get('signature')
+    if not sig:
+        messages.error(request, "Please upload a signature image.")
+    elif not sig.content_type.startswith('image/'):
+        messages.error(request, "The uploaded file must be an image (PNG or JPEG).")
+    elif sig.size > 2 * 1024 * 1024:
+        messages.error(request, "The signature image must be smaller than 2 MB.")
+    else:
+        pdf_bytes = generate_visa_letter_pdf(visa_request, sig.read())
+        response = HttpResponse(pdf_bytes, content_type='application/pdf')
+        response['Content-Disposition'] = 'attachment; filename="visa_letter_{}_{}.pdf"'.format(
+            conference.urlname, visa_request.registration.lastname)
+        return response
+    return redirect('../')
+
+
+def _render_letter_body(visa_request):
+    conference = visa_request.conference
+    if conference.startdate == conference.enddate:
+        confdates = conference.startdate.strftime('%B %d, %Y')
+    else:
+        confdates = '{} – {}'.format(
+            conference.startdate.strftime('%B %d'),
+            conference.enddate.strftime('%B %d, %Y'),
+        )
+    is_speaker = _is_speaker(visa_request.registration)
+
+    with open(VISA_LETTER_TEMPLATE_PATH, 'r', encoding='utf-8') as f:
+        template = jinja2.Template(f.read())
+    return template.render(
+        conference={
+            'name': conference.conferencename,
+            'dates': confdates,
+            'venue': conference.location,
+            'city': conference.visa_letter_city,
+            'country': conference.visa_letter_country,
+        },
+        full_name_passport=visa_request.passport_name,
+        passport_sex=visa_request.passport_sex,
+        date_of_birth=visa_request.date_of_birth.strftime('%d/%m/%Y'),
+        nationality=visa_request.nationality,
+        passport_number=visa_request.passport_number,
+        address=visa_request.home_address,
+        entry_date=visa_request.entry_date.strftime('%d/%m/%Y'),
+        exit_date=visa_request.exit_date.strftime('%d/%m/%Y'),
+        stay_at=visa_request.accommodation,
+        contact=visa_request.contact_info,
+        is_speaker=is_speaker,
+        accommodation_covered=visa_request.accommodation_covered,
+        signer={'signature_text': conference.visa_letter_signer},
+    )
+
+
+def generate_visa_letter_pdf(visa_request, signature_bytes):
+    buf = BytesIO()
+    doc = SimpleDocTemplate(buf, pagesize=A4,
+                            rightMargin=72, leftMargin=72,
+                            topMargin=72, bottomMargin=72)
+    styles = getSampleStyleSheet()
+    body = ParagraphStyle('body', parent=styles['Normal'], fontSize=10, leading=12, spaceAfter=6)
+    right = ParagraphStyle('right', parent=body, alignment=TA_RIGHT)
+
+    today = datetime.now().strftime('%B %d, %Y')
+    story = []
+
+    from PIL import Image as PILImage
+    logo_path = os.path.join(PROJECT_ROOT, 'media', 'img', 'pgeu_logo.png')
+    with PILImage.open(logo_path) as _img:
+        ratio = _img.size[0] / _img.size[1]
+    target_height = 0.85 * inch
+    logo_element = Image(logo_path, width=target_height * ratio, height=target_height)
+    logo_element.hAlign = 'LEFT'
+    address_html = (
+        '<b>PostgreSQL Europe</b><br/>'
+        '61, rue de Lyon<br/>'
+        '75012 PARIS<br/>'
+        'FRANCE<br/>'
+        'Website: https://www.postgresql.eu/<br/>'
+        'Email: board@postgresql.eu'
+    )
+    story.append(Table(
+        [[logo_element, Paragraph(address_html, body)]],
+        colWidths=[4.0 * inch, 2.25 * inch],
+        style=TableStyle([
+            ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+            ('LEFTPADDING', (0, 0), (-1, -1), 0),
+            ('RIGHTPADDING', (0, 0), (-1, -1), 0),
+        ]),
+    ))
+    story.append(Spacer(1, 24))
+
+    embassy_html = '{}<br/>{}'.format(
+        escape(visa_request.embassy_name),
+        escape(visa_request.embassy_address).replace('\n', '<br/>'),
+    )
+    story.append(Table(
+        [[Paragraph(embassy_html, body), Paragraph(today, right)]],
+        colWidths=[3.5 * inch, 2.5 * inch],
+        style=TableStyle([
+            ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+            ('LEFTPADDING', (0, 0), (-1, -1), 0),
+            ('RIGHTPADDING', (0, 0), (-1, -1), 0),
+        ]),
+    ))
+    story.append(Spacer(1, 20))
+
+    scaled = rescale_image_bytes(signature_bytes, (250, 100))
+    letter_content = _render_letter_body(visa_request)
+    for para in letter_content.strip().split('\n\n'):
+        chunk = para.strip()
+        if not chunk:
+            continue
+        if '[SIGNATURE_PLACEHOLDER]' in chunk:
+            before, after = chunk.split('[SIGNATURE_PLACEHOLDER]', 1)
+            if before.strip():
+                story.append(Paragraph(before.strip().replace('\n', ' '), body))
+                story.append(Spacer(1, 6))
+            sig = Image(BytesIO(scaled), width=2.2 * inch, height=0.9 * inch)
+            sig.hAlign = 'LEFT'
+            story.append(sig)
+            story.append(Spacer(1, 6))
+            if after.strip():
+                story.append(Paragraph(after.strip().replace('\n', '<br/>'), body))
+        else:
+            story.append(Paragraph(chunk.replace('\n', ' '), body))
+
+    doc.build(story)
+    return buf.getvalue()

--- a/postgresqleu/urls.py
+++ b/postgresqleu/urls.py
@@ -19,6 +19,7 @@ import postgresqleu.confreg.checkin
 import postgresqleu.confreg.twitter
 import postgresqleu.confreg.api
 import postgresqleu.confreg.upload
+import postgresqleu.confreg.visa
 import postgresqleu.confsponsor.scanning
 import postgresqleu.confwiki.views
 import postgresqleu.account.views
@@ -115,6 +116,7 @@ urlpatterns.extend([
     re_path(r'^events/([^/]+)/feedback/$', postgresqleu.confreg.views.feedback),
     re_path(r'^events/([^/]+)/feedback/(\d+)/$', postgresqleu.confreg.views.feedback_session),
     re_path(r'^events/([^/]+)/feedback/conference/$', postgresqleu.confreg.views.feedback_conference),
+    re_path(r'^events/([^/]+)/register/visa/$', postgresqleu.confreg.visa.visa_letter),
     re_path(r'^events/([^/]+)/schedule/$', postgresqleu.confreg.views.schedule),
     re_path(r'^events/([^/]+)/schedule/fav/$', postgresqleu.confreg.views.schedule_favorite),
     re_path(r'^events/([^/]+)/schedule/ical/$', postgresqleu.confreg.views.schedule_ical),
@@ -266,6 +268,8 @@ urlpatterns.extend([
     re_path(r'^events/admin/(\w+)/scheduleslots/(.*/)?$', postgresqleu.confreg.backendviews.edit_scheduleslots),
     re_path(r'^events/admin/(\w+)/volunteerslots/(.*/)?$', postgresqleu.confreg.backendviews.edit_volunteerslots),
     re_path(r'^events/admin/(\w+)/feedbackquestions/(.*/)?$', postgresqleu.confreg.backendviews.edit_feedbackquestions),
+    re_path(r'^events/admin/(\w+)/visaletters/(\d+)/generate/$', postgresqleu.confreg.visa.admin_visa_letter_generate),
+    re_path(r'^events/admin/(\w+)/visaletters/(.*/)?$', postgresqleu.confreg.backendviews.edit_visaletters),
     re_path(r'^events/admin/(\w+)/discountcodes/(.*/)?$', postgresqleu.confreg.backendviews.edit_discountcodes),
     re_path(r'^events/admin/(\w+)/messaging/(.*/)?$', postgresqleu.confreg.backendviews.edit_messaging),
     re_path(r'^events/admin/(\w+)/accesstokens/(.*/)?$', postgresqleu.confreg.backendviews.edit_accesstokens),

--- a/template.jinja/confreg/registration_dashboard.html
+++ b/template.jinja/confreg/registration_dashboard.html
@@ -135,6 +135,15 @@ spamfilters.
    </p>
  </dd>
 {%endif%}
+{%if conference.visa_letter_enabled %}
+ <dt>Visa letter</dt>
+ <dd>
+   <p>
+     If you need a letter of invitation to support a visa application,
+     <a href="{{ redir_root }}visa/">request or view the status of your visa letter</a>.
+   </p>
+ </dd>
+{%endif%}
  <dt>Registration details</dt>
  <dd>
    <p>

--- a/template.jinja/confreg/visa_letter.html
+++ b/template.jinja/confreg/visa_letter.html
@@ -1,0 +1,59 @@
+{%extends "base.html" %}
+{%block title%}Visa Letter Request - {{conference}}{%endblock%}
+{%block content%}
+<h1>Visa Letter Request<span class="confheader"> - {{conference}}</span></h1>
+
+{%if visa_request %}
+<h2>Status</h2>
+<dl>
+ <dt>Submitted</dt><dd>{{ visa_request.created_at|datetimeformat("%Y-%m-%d %H:%M") }}</dd>
+ <dt>Status</dt><dd>{{ visa_request.get_status_display() }}</dd>
+{%if visa_request.reviewed_at %}
+ <dt>Reviewed</dt><dd>{{ visa_request.reviewed_at|datetimeformat("%Y-%m-%d %H:%M") }}</dd>
+{%endif%}
+</dl>
+
+{%if visa_request.status == 'pending' %}
+<p>Your visa letter request has been received and is awaiting review by conference staff.</p>
+{%elif visa_request.status == 'approved' %}
+<p>Your visa letter request has been approved. Conference staff will email the PDF letter to you.</p>
+{%elif visa_request.status == 'rejected' %}
+<p>Your visa letter request was not approved. If you have any questions, please contact the conference organisers at <a href="mailto:{{conference.contactaddr}}">{{conference.contactaddr}}</a>.</p>
+{%elif visa_request.status == 'changes_needed' %}
+<p><b>Conference staff have asked you to update your request before it can be processed.</b></p>
+{%if visa_request.admin_notes %}
+<p><b>Notes from staff:</b></p>
+<blockquote>{{ visa_request.admin_notes }}</blockquote>
+{%endif%}
+<p>Please update the details below and re-submit. Your request will go back to staff for review.</p>
+{%endif%}
+{%endif%}
+
+{%if form %}
+{%if not visa_request %}
+<div class="alert alert-info">
+  <p><b>Important:</b> This form is for requesting an official visa letter to support your visa application. Please ensure all information is accurate as it will appear on the official letter.</p>
+  <p>Visa letters are available to attendees with full payment confirmed, speakers, volunteers, and conference staff.</p>
+</div>
+<p>Provide all details exactly as they appear on your passport.</p>
+{%endif%}
+
+{%if form.errors %}
+<p><b style="color:red;">Please correct the errors below.</b></p>
+{%endif%}
+<form method="post" action=".">{{ csrf_input }}
+<table>
+{%for field in form %}
+ <tr>
+  <th>{{ field.label_tag() }}</th>
+  <td>{{ field.errors }}{{ field }}
+  {%if field.help_text %}<br/><small>{{ field.help_text }}</small>{%endif%}
+  </td>
+ </tr>
+{%endfor%}
+</table>
+<input type="submit" value="{%if visa_request %}Re-submit{%else%}Submit{%endif%} visa letter request">
+</form>
+{%endif%}
+
+{%endblock%}

--- a/template/confreg/admin_dashboard_single.html
+++ b/template/confreg/admin_dashboard_single.html
@@ -28,6 +28,9 @@
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn {%if pending_waitlist%}btn-warning{%else%}btn-default{%endif%} btn-block" href="/events/admin/{{c.urlname}}/waitlist/">Waitlist</a></div>
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn btn-default btn-block" href="/events/admin/{{c.urlname}}/transfer/">Transfer registration</a></div>
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn {%if pending_cancel_requests%}btn-warning{%else%}btn-default{%endif%} btn-block" href="/events/admin/{{c.urlname}}/cancelrequests/">Cancellation requests</a></div>
+{%if c.visa_letter_enabled %}
+  <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn {%if pending_visa_requests%}btn-warning{%else%}btn-default{%endif%} btn-block" href="/events/admin/{{c.urlname}}/visaletters/">Visa letter requests</a></div>
+{%endif%}
 </div>
 <div class="row">
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn btn-default btn-block" href="/events/admin/{{c.urlname}}/mail/">Attendee emails</a></div>

--- a/template/confreg/visa_letter_template.j2
+++ b/template/confreg/visa_letter_template.j2
@@ -1,0 +1,51 @@
+Dear Sir or Madam:
+
+I represent PostgreSQL Europe, a not-for-profit association dedicated to
+the promotion of the PostgreSQL Open Source database project within
+Europe, registered in France. We are holding one of our main annual
+conferences, {{ conference.name }}, on the {{ conference.dates }} in the 
+{{ conference.venue }}.
+
+Please accept this letter in support of the short stay visa application
+of <b>{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}</b>
+to travel to {{ conference.city }}, {{ conference.country }} in order to {% if is_speaker %}give a presentation
+at the {% else %}attend the {% endif %}{{ conference.name }} conference.
+{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}
+will be in {{ conference.country }} from {{ entry_date }} to {{ exit_date }}.
+
+{% if accommodation_covered %}
+PostgreSQL Europe will be responsible for all accommodation and travel
+expenses. Accommodation will be paid by PostgreSQL Europe directly,
+travel expenses will be reimbursed after the event.
+{% else %}
+{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}
+will be responsible for all {% if passport_sex == 'male' %}his{% else %}her{% endif %}
+accommodation and travel expenses.
+{% if is_speaker %}As a speaker at the event, {% if passport_sex == 'male' %}his{% else %}her{% endif %}
+registration fees are waived.
+{% else %}{% if passport_sex == 'male' %}His{% else %}Her{% endif %} registration
+fees for the events are paid in full.{% endif %} While in {{ conference.country }},
+{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}
+will be staying at {{ stay_at }}.
+{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}
+can be reached there at {{ contact }}.
+{% endif %}
+
+Full name as shown on passport: {{ full_name_passport }}<br/>
+Date of birth (DD/MM/YYYY): {{ date_of_birth }}<br/>
+Nationality: {{ nationality }}<br/>
+Passport no: {{ passport_number }}<br/>
+Address: {{ address }}
+
+{{ conference.name }} is one of the main conferences held every year by
+PostgreSQL Europe, and is held every year in a European City. PostgreSQL 
+is a global project and we welcome developers and users from around the 
+world to share experiences and plans at our events.
+
+We thank you for your consideration of our request.
+
+Yours faithfully,
+
+[SIGNATURE_PLACEHOLDER]
+
+{{ signer.signature_text|e|replace('\n', '<br/>')|safe }}


### PR DESCRIPTION
Workflow:

1. Attendee submits passport / embassy / travel details via `/events/<conf>/register/visa/`
2. Staff reviews the request in the conf admin and approves, rejects, or marks 'changes needed' with notes filled in for the attendee to re-edit (status goes back to pending on re-submit)
3. Staff clicks 'Generate PDF' on approved request, uploads a fresh signature image (not saved server-side, required every time), gets the PDF download
4. Staff emails the PDF to the attendee manually

* Enabled per-conf via a new `Conference.visa_letter_enabled` flag
* Per-conf `visa_letter_city` / `visa_letter_country` / `visa_letter_signer` fields are rendered into the letter
* Personal data (the visa requests) wiped by conference purge data action