### PR TITLE
Add anonymous diversity survey feature

### DIFF
--- a/postgresqleu/confreg/backendforms.py
+++ b/postgresqleu/confreg/backendforms.py
@@ -40,6 +40,7 @@ from postgresqleu.confsponsor.benefitclasses import get_benefit_id
 from postgresqleu.confreg.models import Conference, ConferenceRegistration, ConferenceAdditionalOption
 from postgresqleu.confreg.models import RegistrationClass, RegistrationType, RegistrationDay
 from postgresqleu.confreg.models import ConferenceFeedbackQuestion, Speaker
+from postgresqleu.confreg.models import VisaLetterRequest
 from postgresqleu.confreg.models import ConferenceSession, Track, Room, ConferenceSessionTag
 from postgresqleu.confreg.models import ConferenceSessionSlides
 from postgresqleu.confreg.models import ConferenceSessionScheduleSlot, VolunteerSlot
@@ -93,7 +94,8 @@ class BackendConferenceForm(BackendForm):
                   'callforpapersmaxsubmissions', 'skill_levels', 'showvotes', 'scoring_method', 'callforpaperstags', 'callforpapersrecording', 'sendwelcomemail',
                   'tickets', 'confirmpolicy', 'queuepartitioning', 'invoice_autocancel_hours', 'attendees_before_waitlist',
                   'transfer_cost', 'initial_common_countries', 'jinjaenabled', 'dynafields', 'scannerfields',
-                  'videoproviders', ]
+                  'videoproviders',
+                  'visa_letter_enabled', 'visa_letter_city', 'visa_letter_country', 'visa_letter_signer', ]
 
     def fix_fields(self):
         self.selectize_multiple_fields['volunteers'] = RegisteredUsersLookup(self.conference)
@@ -112,6 +114,7 @@ class BackendConferenceForm(BackendForm):
         {'id': 'callforpapers', 'legend': 'Call for papers', 'fields': ['callforpapersmaxsubmissions', 'skill_levels', 'callforpaperstags', 'callforpapersrecording', 'showvotes', 'scoring_method']},
         {'id': 'roles', 'legend': 'Roles', 'fields': ['testers', 'talkvoters', 'staff', 'volunteers', 'checkinprocessors', ]},
         {'id': 'display', 'legend': 'Display', 'fields': ['jinjaenabled', 'videoproviders', ]},
+        {'id': 'visaletters', 'legend': 'Visa letters', 'fields': ['visa_letter_enabled', 'visa_letter_city', 'visa_letter_country', 'visa_letter_signer', ]},
         {'id': 'legacy', 'legend': 'Legacy', 'fields': ['schedulewidth', 'pixelsperminute']},
     ]
 
@@ -2027,3 +2030,59 @@ class BackendRegistrationDmForm(django.forms.Form):
         if maxlength:
             self.fields['message'].max_length = maxlength
             self.fields['message'].help_text = 'Maximum message length for this provider is {} characters.'.format(maxlength)
+
+
+class BackendVisaLetterRequestForm(BackendForm):
+    helplink = "visaletters"
+    list_fields = ['registration', 'status', 'created_at']
+    readonly_fields = [
+        'passport_name', 'date_of_birth', 'passport_number', 'nationality', 'home_address',
+        'embassy_name', 'embassy_address',
+        'entry_date', 'exit_date', 'accommodation', 'contact_info',
+    ]
+    exclude_date_validators = ['date_of_birth', 'entry_date', 'exit_date']
+    queryset_select_related = ['registration']
+
+    class Meta:
+        model = VisaLetterRequest
+        fields = [
+            'registration',
+            'passport_name', 'passport_sex', 'date_of_birth', 'passport_number', 'nationality', 'home_address',
+            'embassy_name', 'embassy_address',
+            'entry_date', 'exit_date', 'accommodation', 'contact_info',
+            'status', 'admin_notes', 'accommodation_covered',
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['registration'].disabled = True
+        self.fields['passport_sex'].disabled = True
+        if self.instance.pk and self.instance.status == VisaLetterRequest.STATUS_APPROVED:
+            self.extrabuttons = list(self.extrabuttons) + [('Generate PDF', 'generate/')]
+            self.formnote = (
+                '<dialog id="visa-pdf-dialog" style="max-width:32em;padding:1.5em;border:1px solid #888;">'
+                '<h4>Generate visa letter PDF</h4>'
+                '<p><b>The signature image is NOT saved on the server.</b> '
+                'It is held in memory only long enough to render the PDF and is then discarded. '
+                'You must upload it every time you generate a PDF for any attendee.</p>'
+                '<p><label>Signature image (PNG or JPEG, &le; 2&nbsp;MB):<br>'
+                '<input type="file" name="signature" accept="image/png,image/jpeg" required></label></p>'
+                '<p style="text-align:right;">'
+                '<button type="button" onclick="this.closest(\'dialog\').close()">Cancel</button> '
+                '<button type="submit" formaction="generate/" formenctype="multipart/form-data" formnovalidate>Generate PDF</button>'
+                '</p>'
+                '</dialog>'
+                '<script>'
+                'document.addEventListener("DOMContentLoaded",function(){'
+                'var d=document.getElementById("visa-pdf-dialog");if(!d)return;'
+                'document.querySelectorAll("a.btn").forEach(function(a){'
+                'if((a.getAttribute("href")||"").endsWith("generate/")){'
+                'a.addEventListener("click",function(e){e.preventDefault();d.showModal();});}});});'
+                '</script>'
+            )
+
+    def save(self, commit=True):
+        if self.instance.pk and 'status' in self.changed_data:
+            self.instance.reviewed_by = self.request.user
+            self.instance.reviewed_at = timezone.now()
+        return super().save(commit=commit)

--- a/postgresqleu/confreg/backendforms.py
+++ b/postgresqleu/confreg/backendforms.py
@@ -95,7 +95,8 @@ class BackendConferenceForm(BackendForm):
                   'tickets', 'confirmpolicy', 'queuepartitioning', 'invoice_autocancel_hours', 'attendees_before_waitlist',
                   'transfer_cost', 'initial_common_countries', 'jinjaenabled', 'dynafields', 'scannerfields',
                   'videoproviders',
-                  'visa_letter_enabled', 'visa_letter_city', 'visa_letter_country', 'visa_letter_signer', ]
+                  'visa_letter_enabled', 'visa_letter_city', 'visa_letter_country', 'visa_letter_signer',
+                  'diversity_survey_enabled', ]
 
     def fix_fields(self):
         self.selectize_multiple_fields['volunteers'] = RegisteredUsersLookup(self.conference)
@@ -115,6 +116,7 @@ class BackendConferenceForm(BackendForm):
         {'id': 'roles', 'legend': 'Roles', 'fields': ['testers', 'talkvoters', 'staff', 'volunteers', 'checkinprocessors', ]},
         {'id': 'display', 'legend': 'Display', 'fields': ['jinjaenabled', 'videoproviders', ]},
         {'id': 'visaletters', 'legend': 'Visa letters', 'fields': ['visa_letter_enabled', 'visa_letter_city', 'visa_letter_country', 'visa_letter_signer', ]},
+        {'id': 'diversitysurvey', 'legend': 'Diversity survey', 'fields': ['diversity_survey_enabled', ]},
         {'id': 'legacy', 'legend': 'Legacy', 'fields': ['schedulewidth', 'pixelsperminute']},
     ]
 

--- a/postgresqleu/confreg/backendviews.py
+++ b/postgresqleu/confreg/backendviews.py
@@ -36,6 +36,7 @@ from .models import ShirtSize
 from .models import PendingAdditionalOrder
 from .models import ConferenceTweetQueue
 from .models import MessagingProvider
+from .models import VisaLetterRequest
 from .models import RefundPattern
 
 from postgresqleu.invoices.models import Invoice
@@ -51,6 +52,7 @@ from .backendforms import BackendTrackForm, BackendRoomForm, BackendConferenceSe
 from .backendforms import BackendConferenceSpeakerForm, BackendGlobalSpeakerForm, BackendTagForm
 from .backendforms import BackendConferenceSessionSlotForm, BackendVolunteerSlotForm
 from .backendforms import BackendFeedbackQuestionForm, BackendDiscountCodeForm
+from .backendforms import BackendVisaLetterRequestForm
 from .backendforms import BackendAccessTokenForm
 from .backendforms import BackendConferenceSeriesForm
 from .backendforms import BackendTshirtSizeForm
@@ -267,6 +269,15 @@ def edit_feedbackquestions(request, urlname, rest):
                                urlname,
                                BackendFeedbackQuestionForm,
                                rest)
+
+
+def edit_visaletters(request, urlname, rest):
+    return backend_list_editor(request,
+                               urlname,
+                               BackendVisaLetterRequestForm,
+                               rest,
+                               allow_new=False,
+                               allow_delete=True)
 
 
 def edit_discountcodes(request, urlname, rest):
@@ -729,6 +740,7 @@ def purge_personal_data(request, urlname):
         exec_no_result("INSERT INTO confreg_aggregateddietary (conference_id, dietary, num) SELECT conference_id, lower(dietary), count(*) FROM confreg_conferenceregistration WHERE conference_id=%(confid)s AND dietary IS NOT NULL AND dietary != '' GROUP BY conference_id, lower(dietary)", {'confid': conference.id, })
         exec_no_result("INSERT INTO confreg_aggregatepronouns (conference_id, pronouns, num) SELECT conference_id, pronouns, count(*) FROM confreg_conferenceregistration WHERE conference_id=%(confid)s GROUP BY conference_id, pronouns", {'confid': conference.id, })
         exec_no_result("UPDATE confreg_conferenceregistration SET shirtsize_id=NULL, dietary='', phone='', address='', pronouns=0 WHERE conference_id=%(confid)s", {'confid': conference.id, })
+        VisaLetterRequest.objects.filter(conference=conference).delete()
         conference.personal_data_purged = timezone.now()
         conference.save()
         messages.info(request, "Personal data purged from conference")

--- a/postgresqleu/confreg/backendviews.py
+++ b/postgresqleu/confreg/backendviews.py
@@ -741,6 +741,7 @@ def purge_personal_data(request, urlname):
         exec_no_result("INSERT INTO confreg_aggregatepronouns (conference_id, pronouns, num) SELECT conference_id, pronouns, count(*) FROM confreg_conferenceregistration WHERE conference_id=%(confid)s GROUP BY conference_id, pronouns", {'confid': conference.id, })
         exec_no_result("UPDATE confreg_conferenceregistration SET shirtsize_id=NULL, dietary='', phone='', address='', pronouns=0 WHERE conference_id=%(confid)s", {'confid': conference.id, })
         VisaLetterRequest.objects.filter(conference=conference).delete()
+        ConferenceRegistration.objects.filter(conference=conference).update(diversity_survey_response=None)
         conference.personal_data_purged = timezone.now()
         conference.save()
         messages.info(request, "Personal data purged from conference")

--- a/postgresqleu/confreg/migrations/0126_visaletter.py
+++ b/postgresqleu/confreg/migrations/0126_visaletter.py
@@ -1,0 +1,66 @@
+# Generated for the visa letter feature.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('confreg', '0125_index_conference_enddate'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='conference',
+            name='visa_letter_enabled',
+            field=models.BooleanField(default=False, help_text='Allow eligible attendees to request a visa invitation letter', verbose_name='Visa letters'),
+        ),
+        migrations.AddField(
+            model_name='conference',
+            name='visa_letter_city',
+            field=models.CharField(blank=True, help_text='City the conference is held in, as it should appear in the visa letter (e.g. "Berlin")', max_length=100, verbose_name='Visa letter city'),
+        ),
+        migrations.AddField(
+            model_name='conference',
+            name='visa_letter_country',
+            field=models.CharField(blank=True, help_text='Country the conference is held in, as it should appear in the visa letter (e.g. "Germany")', max_length=100, verbose_name='Visa letter country'),
+        ),
+        migrations.AddField(
+            model_name='conference',
+            name='visa_letter_signer',
+            field=models.TextField(blank=True, help_text='Multi-line text printed below the signature image: name, title, address, phone, email', verbose_name='Visa letter signer'),
+        ),
+        migrations.CreateModel(
+            name='VisaLetterRequest',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('status', models.CharField(choices=[('pending', 'Pending review'), ('changes_needed', 'Changes needed'), ('approved', 'Approved'), ('rejected', 'Rejected')], default='pending', max_length=20)),
+                ('reviewed_at', models.DateTimeField(blank=True, null=True)),
+                ('admin_notes', models.TextField(blank=True, default='', verbose_name='Admin notes')),
+                ('accommodation_covered', models.BooleanField(default=False, help_text='Tick if accommodation and travel costs are covered for this attendee; the visa letter will state this.', verbose_name='Accommodation and travel covered')),
+                ('passport_name', models.CharField(max_length=200, verbose_name='Full name on passport')),
+                ('passport_sex', models.CharField(choices=[('male', 'Male'), ('female', 'Female')], max_length=10, verbose_name='Sex (as on passport)')),
+                ('date_of_birth', models.DateField(verbose_name='Date of birth')),
+                ('passport_number', models.CharField(max_length=50, verbose_name='Passport number')),
+                ('nationality', models.CharField(max_length=100, verbose_name='Nationality')),
+                ('home_address', models.TextField(verbose_name='Home address')),
+                ('embassy_name', models.CharField(max_length=200, verbose_name='Embassy / consulate name')),
+                ('embassy_address', models.TextField(verbose_name='Embassy / consulate address')),
+                ('entry_date', models.DateField(verbose_name='Planned entry date')),
+                ('exit_date', models.DateField(verbose_name='Planned exit date')),
+                ('accommodation', models.CharField(max_length=200, verbose_name='Accommodation while in country')),
+                ('contact_info', models.CharField(max_length=200, verbose_name='Contact info while in country')),
+                ('conference', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='confreg.conference')),
+                ('registration', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='confreg.conferenceregistration')),
+                ('reviewed_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'ordering': ('-created_at',),
+                'unique_together': {('conference', 'registration')},
+            },
+        ),
+    ]

--- a/postgresqleu/confreg/migrations/0127_diversitysurvey.py
+++ b/postgresqleu/confreg/migrations/0127_diversitysurvey.py
@@ -1,0 +1,41 @@
+# Generated for the diversity survey feature.
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('confreg', '0126_visaletter'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='conference',
+            name='diversity_survey_enabled',
+            field=models.BooleanField(default=False, help_text='Offer attendees an anonymous demographic survey after registering', verbose_name='Diversity survey'),
+        ),
+        migrations.AddField(
+            model_name='conferenceregistration',
+            name='diversity_survey_response',
+            field=models.BooleanField(blank=True, default=None, null=True),
+        ),
+        migrations.CreateModel(
+            name='DiversitySurveyAnswer',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('age_range', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('18-24', '18-24'), ('25-34', '25-34'), ('35-44', '35-44'), ('45-54', '45-54'), ('55-64', '55-64'), ('65+', '65 or older')], max_length=20, verbose_name='Age range')),
+                ('gender_identity', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('woman', 'Woman'), ('man', 'Man'), ('non-binary', 'Non-binary'), ('other', 'Other')], max_length=20, verbose_name='Gender identity')),
+                ('ethnicity', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('white', 'White / European descent'), ('asian', 'Asian'), ('black', 'Black / African descent'), ('hispanic', 'Hispanic / Latino'), ('middle-eastern', 'Middle Eastern / North African'), ('mixed', 'Mixed or multiple ethnicities'), ('other', 'Other')], max_length=20, verbose_name='Ethnicity')),
+                ('career_level', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('student', 'Student'), ('entry', 'Entry level (0–2 years)'), ('mid', 'Mid level (3–7 years)'), ('senior', 'Senior level (8–15 years)'), ('lead', 'Lead / Principal (15+ years)'), ('management', 'Management'), ('executive', 'Executive'), ('other', 'Other')], max_length=20, verbose_name='Career level')),
+                ('years_in_tech', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('0-1', '0–1 years'), ('2-5', '2–5 years'), ('6-10', '6–10 years'), ('11-15', '11–15 years'), ('16-20', '16–20 years'), ('20+', 'More than 20 years')], max_length=10, verbose_name='Years in technology')),
+                ('education_level', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('high-school', 'High school'), ('bachelors', "Bachelor's degree"), ('masters', "Master's degree"), ('phd', 'PhD or Doctorate'), ('bootcamp', 'Coding bootcamp'), ('self-taught', 'Self-taught'), ('other', 'Other')], max_length=20, verbose_name='Highest education level')),
+                ('company_size', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('1-10', '1–10 employees'), ('11-50', '11–50 employees'), ('51-200', '51–200 employees'), ('201-1000', '201–1000 employees'), ('1000+', 'More than 1000 employees'), ('freelance', 'Freelancer / Consultant'), ('non-profit', 'Non-profit organisation'), ('government', 'Government'), ('academic', 'Academic institution')], max_length=20, verbose_name='Company size')),
+                ('first_time_attendee', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('yes', 'Yes'), ('no', 'No')], max_length=3, verbose_name='Is this your first PostgreSQL conference?')),
+                ('how_heard', models.CharField(blank=True, choices=[('', 'Prefer not to say'), ('website', 'PostgreSQL website'), ('social-media', 'Social media'), ('colleague', 'Colleague or friend'), ('previous-attendee', 'Previous conference attendee'), ('mailing-list', 'Mailing list'), ('blog', 'Blog or news article'), ('employer', 'Employer'), ('other', 'Other')], max_length=20, verbose_name='How did you hear about this conference?')),
+                ('accessibility_needs', models.TextField(blank=True, verbose_name='Accessibility accommodations used (optional)')),
+                ('conference', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='confreg.conference')),
+            ],
+        ),
+    ]

--- a/postgresqleu/confreg/models.py
+++ b/postgresqleu/confreg/models.py
@@ -260,6 +260,8 @@ class Conference(models.Model):
     visa_letter_country = models.CharField(max_length=100, blank=True, null=False, verbose_name="Visa letter country", help_text="Country the conference is held in, as it should appear in the visa letter (e.g. \"Germany\")")
     visa_letter_signer = models.TextField(blank=True, null=False, verbose_name="Visa letter signer", help_text="Multi-line text printed below the signature image: name, title, address, phone, email")
 
+    diversity_survey_enabled = models.BooleanField(blank=False, null=False, default=False, verbose_name="Diversity survey", help_text="Offer attendees an anonymous demographic survey after registering")
+
     # Attributes that are safe to access in jinja templates
     _safe_attributes = ('registrationopen', 'registrationtimerange', 'IsRegistrationOpen',
                         'startdate', 'enddate',
@@ -270,7 +272,7 @@ class Conference(models.Model):
                         'confirmpolicy', 'conferencedatestr', 'location',
                         'feedbackopen', 'skill_levels', 'urlname', 'conferencename',
                         'series', 'sendwelcomemail', 'scannerfields_list',
-                        'vat_registrations', 'visa_letter_enabled',
+                        'vat_registrations', 'visa_letter_enabled', 'diversity_survey_enabled',
     )
 
     def safe_export(self):
@@ -704,6 +706,12 @@ class ConferenceRegistration(models.Model):
 
     # Favorite-marked sessions
     favs = ArrayField(models.IntegerField(), null=False, blank=True, default=list)
+
+    # Diversity survey response state. Tri-state flag (null = not yet asked,
+    # True = submitted, False = explicitly declined). Used purely to drive the
+    # prompt logic; the actual demographic answers go to DiversitySurveyAnswer
+    # with no FK back here, so this row holds no clue about what was answered.
+    diversity_survey_response = models.BooleanField(null=True, blank=True, default=None)
 
     _unsafe_attributes = [
         'messaging_copiedfrom', 'messaging_copiedfrom_id',
@@ -2041,3 +2049,104 @@ class VisaLetterRequest(AttendeeSubmission):
 
     def purge_personal_data(self):
         self.delete()
+
+
+class DiversitySurveyAnswer(models.Model):
+    """Anonymous demographic survey response. Intentionally carries no FK or timestamp
+    that could be correlated back to a specific attendee."""
+    AGE_RANGE_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('18-24', '18-24'),
+        ('25-34', '25-34'),
+        ('35-44', '35-44'),
+        ('45-54', '45-54'),
+        ('55-64', '55-64'),
+        ('65+', '65 or older'),
+    )
+    GENDER_IDENTITY_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('woman', 'Woman'),
+        ('man', 'Man'),
+        ('non-binary', 'Non-binary'),
+        ('other', 'Other'),
+    )
+    ETHNICITY_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('white', 'White / European descent'),
+        ('asian', 'Asian'),
+        ('black', 'Black / African descent'),
+        ('hispanic', 'Hispanic / Latino'),
+        ('middle-eastern', 'Middle Eastern / North African'),
+        ('mixed', 'Mixed or multiple ethnicities'),
+        ('other', 'Other'),
+    )
+    CAREER_LEVEL_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('student', 'Student'),
+        ('entry', 'Entry level (0–2 years)'),
+        ('mid', 'Mid level (3–7 years)'),
+        ('senior', 'Senior level (8–15 years)'),
+        ('lead', 'Lead / Principal (15+ years)'),
+        ('management', 'Management'),
+        ('executive', 'Executive'),
+        ('other', 'Other'),
+    )
+    YEARS_IN_TECH_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('0-1', '0–1 years'),
+        ('2-5', '2–5 years'),
+        ('6-10', '6–10 years'),
+        ('11-15', '11–15 years'),
+        ('16-20', '16–20 years'),
+        ('20+', 'More than 20 years'),
+    )
+    EDUCATION_LEVEL_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('high-school', 'High school'),
+        ('bachelors', "Bachelor's degree"),
+        ('masters', "Master's degree"),
+        ('phd', 'PhD or Doctorate'),
+        ('bootcamp', 'Coding bootcamp'),
+        ('self-taught', 'Self-taught'),
+        ('other', 'Other'),
+    )
+    COMPANY_SIZE_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('1-10', '1–10 employees'),
+        ('11-50', '11–50 employees'),
+        ('51-200', '51–200 employees'),
+        ('201-1000', '201–1000 employees'),
+        ('1000+', 'More than 1000 employees'),
+        ('freelance', 'Freelancer / Consultant'),
+        ('non-profit', 'Non-profit organisation'),
+        ('government', 'Government'),
+        ('academic', 'Academic institution'),
+    )
+    FIRST_TIME_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('yes', 'Yes'),
+        ('no', 'No'),
+    )
+    HOW_HEARD_CHOICES = (
+        ('', 'Prefer not to say'),
+        ('website', 'PostgreSQL website'),
+        ('social-media', 'Social media'),
+        ('colleague', 'Colleague or friend'),
+        ('previous-attendee', 'Previous conference attendee'),
+        ('mailing-list', 'Mailing list'),
+        ('blog', 'Blog or news article'),
+        ('employer', 'Employer'),
+        ('other', 'Other'),
+    )
+
+    conference = models.ForeignKey(Conference, on_delete=models.CASCADE)
+    age_range = models.CharField(max_length=20, blank=True, choices=AGE_RANGE_CHOICES, verbose_name="Age range")
+    gender_identity = models.CharField(max_length=20, blank=True, choices=GENDER_IDENTITY_CHOICES, verbose_name="Gender identity")
+    ethnicity = models.CharField(max_length=20, blank=True, choices=ETHNICITY_CHOICES, verbose_name="Ethnicity")
+    career_level = models.CharField(max_length=20, blank=True, choices=CAREER_LEVEL_CHOICES, verbose_name="Career level")
+    years_in_tech = models.CharField(max_length=10, blank=True, choices=YEARS_IN_TECH_CHOICES, verbose_name="Years in technology")
+    education_level = models.CharField(max_length=20, blank=True, choices=EDUCATION_LEVEL_CHOICES, verbose_name="Highest education level")
+    company_size = models.CharField(max_length=20, blank=True, choices=COMPANY_SIZE_CHOICES, verbose_name="Company size")
+    first_time_attendee = models.CharField(max_length=3, blank=True, choices=FIRST_TIME_CHOICES, verbose_name="Is this your first PostgreSQL conference?")
+    how_heard = models.CharField(max_length=20, blank=True, choices=HOW_HEARD_CHOICES, verbose_name="How did you hear about this conference?")
+    accessibility_needs = models.TextField(blank=True, verbose_name="Accessibility accommodations used (optional)")

--- a/postgresqleu/confreg/models.py
+++ b/postgresqleu/confreg/models.py
@@ -255,6 +255,11 @@ class Conference(models.Model):
     key_private = models.TextField(null=False, blank=True, verbose_name="Private RSA key for signatures")
     web_origins = models.CharField(null=False, blank=True, max_length=1000, verbose_name="Allowed web origins for API calls (comma separated list)")
 
+    visa_letter_enabled = models.BooleanField(blank=False, null=False, default=False, verbose_name="Visa letters", help_text="Allow eligible attendees to request a visa invitation letter")
+    visa_letter_city = models.CharField(max_length=100, blank=True, null=False, verbose_name="Visa letter city", help_text="City the conference is held in, as it should appear in the visa letter (e.g. \"Berlin\")")
+    visa_letter_country = models.CharField(max_length=100, blank=True, null=False, verbose_name="Visa letter country", help_text="Country the conference is held in, as it should appear in the visa letter (e.g. \"Germany\")")
+    visa_letter_signer = models.TextField(blank=True, null=False, verbose_name="Visa letter signer", help_text="Multi-line text printed below the signature image: name, title, address, phone, email")
+
     # Attributes that are safe to access in jinja templates
     _safe_attributes = ('registrationopen', 'registrationtimerange', 'IsRegistrationOpen',
                         'startdate', 'enddate',
@@ -265,7 +270,7 @@ class Conference(models.Model):
                         'confirmpolicy', 'conferencedatestr', 'location',
                         'feedbackopen', 'skill_levels', 'urlname', 'conferencename',
                         'series', 'sendwelcomemail', 'scannerfields_list',
-                        'vat_registrations',
+                        'vat_registrations', 'visa_letter_enabled',
     )
 
     def safe_export(self):
@@ -1963,3 +1968,76 @@ class ConferenceRemovedData(models.Model):
             ('urlname', 'description'),
         )
         ordering = ('urlname', 'description')
+
+
+class AttendeeSubmission(models.Model):
+    """Abstract base for per-registration form submissions tied to a conference.
+
+    Concrete subclasses add their own data fields and override purge_personal_data()
+    to either delete the row or null out personal fields, depending on whether any
+    aggregate (e.g. anonymised survey responses) should survive a personal-data purge.
+    """
+    conference = models.ForeignKey(Conference, on_delete=models.CASCADE)
+    registration = models.ForeignKey(ConferenceRegistration, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+        ordering = ('-created_at', )
+
+    def purge_personal_data(self):
+        raise NotImplementedError
+
+
+class VisaLetterRequest(AttendeeSubmission):
+    STATUS_PENDING = 'pending'
+    STATUS_CHANGES_NEEDED = 'changes_needed'
+    STATUS_APPROVED = 'approved'
+    STATUS_REJECTED = 'rejected'
+    STATUS_CHOICES = (
+        (STATUS_PENDING, 'Pending review'),
+        (STATUS_CHANGES_NEEDED, 'Changes needed'),
+        (STATUS_APPROVED, 'Approved'),
+        (STATUS_REJECTED, 'Rejected'),
+    )
+
+    SEX_CHOICES = (
+        ('male', 'Male'),
+        ('female', 'Female'),
+    )
+
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_PENDING)
+    reviewed_at = models.DateTimeField(null=True, blank=True)
+    reviewed_by = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL, related_name='+')
+    admin_notes = models.TextField(blank=True, null=False, default='', verbose_name="Admin notes")
+    accommodation_covered = models.BooleanField(blank=False, null=False, default=False, verbose_name="Accommodation and travel covered", help_text="Tick if accommodation and travel costs are covered for this attendee; the visa letter will state this.")
+
+    passport_name = models.CharField(max_length=200, verbose_name="Full name on passport")
+    passport_sex = models.CharField(max_length=10, choices=SEX_CHOICES, verbose_name="Sex (as on passport)")
+    date_of_birth = models.DateField(verbose_name="Date of birth")
+    passport_number = models.CharField(max_length=50, verbose_name="Passport number")
+    nationality = models.CharField(max_length=100, verbose_name="Nationality")
+    home_address = models.TextField(verbose_name="Home address")
+    embassy_name = models.CharField(max_length=200, verbose_name="Embassy / consulate name")
+    embassy_address = models.TextField(verbose_name="Embassy / consulate address")
+    entry_date = models.DateField(verbose_name="Planned entry date")
+    exit_date = models.DateField(verbose_name="Planned exit date")
+    accommodation = models.CharField(max_length=200, verbose_name="Accommodation while in country")
+    contact_info = models.CharField(max_length=200, verbose_name="Contact info while in country")
+
+    class Meta(AttendeeSubmission.Meta):
+        unique_together = (('conference', 'registration'), )
+
+    def __str__(self):
+        return '{} ({})'.format(self.registration.fullname, self.get_status_display())
+
+    def _display_registration(self, cache):
+        return self.registration.fullname
+
+    def clean(self):
+        super().clean()
+        if self.entry_date and self.exit_date and self.exit_date <= self.entry_date:
+            raise ValidationError({'exit_date': 'Exit date must be after entry date.'})
+
+    def purge_personal_data(self):
+        self.delete()

--- a/postgresqleu/confreg/survey.py
+++ b/postgresqleu/confreg/survey.py
@@ -1,0 +1,146 @@
+import csv
+from collections import OrderedDict
+
+from django import forms
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.db.models import Count
+from django.http import Http404, HttpResponse
+from django.shortcuts import get_object_or_404, redirect, render
+
+from .models import Conference, ConferenceRegistration, DiversitySurveyAnswer
+from .util import get_authenticated_conference, render_conference_response
+
+
+_AGGREGATE_FIELDS = (
+    'age_range', 'gender_identity', 'ethnicity', 'career_level',
+    'years_in_tech', 'education_level', 'company_size',
+    'first_time_attendee', 'how_heard',
+)
+
+# Characters that spreadsheets interpret as formula triggers in CSV cells.
+_CSV_FORMULA_PREFIXES = ('=', '+', '-', '@', '\t', '\r')
+
+
+def _csv_safe(value):
+    s = '' if value is None else str(value)
+    if s and s[0] in _CSV_FORMULA_PREFIXES:
+        s = "'" + s
+    return s
+
+
+class DiversitySurveyForm(forms.ModelForm):
+    class Meta:
+        model = DiversitySurveyAnswer
+        fields = [
+            'age_range', 'gender_identity', 'ethnicity', 'career_level',
+            'years_in_tech', 'education_level', 'company_size',
+            'first_time_attendee', 'how_heard', 'accessibility_needs',
+        ]
+        widgets = {
+            'accessibility_needs': forms.Textarea(attrs={'rows': 3, 'cols': 60}),
+        }
+
+
+def _set_response(registration, value):
+    # Use .update() so ConferenceRegistration.lastmodified does NOT change.
+    # If it did, the lastmodified timestamp would leak the response time and
+    # could be correlated with DiversitySurveyAnswer rows, breaking anonymity.
+    ConferenceRegistration.objects.filter(pk=registration.pk).update(diversity_survey_response=value)
+
+
+@login_required
+@transaction.atomic
+def diversity_survey(request, confname):
+    conference = get_object_or_404(Conference, urlname=confname)
+    if not conference.diversity_survey_enabled:
+        raise Http404
+    try:
+        registration = ConferenceRegistration.objects.get(
+            conference=conference, attendee=request.user, canceledat__isnull=True)
+    except ConferenceRegistration.DoesNotExist:
+        messages.error(request, "You must be registered for this conference to take the survey.")
+        return redirect('/events/{}/'.format(confname))
+
+    if registration.diversity_survey_response is True:
+        return render_conference_response(request, conference, 'reg', 'confreg/diversity_survey.html', {
+            'form': None, 'already_submitted': True, 'declined': False,
+        })
+
+    if request.method == 'POST':
+        if 'skip' in request.POST:
+            _set_response(registration, False)
+            messages.info(request, "You can take the diversity survey later from your registration dashboard.")
+            return redirect('../')
+        form = DiversitySurveyForm(request.POST)
+        if form.is_valid():
+            answer = form.save(commit=False)
+            answer.conference = conference
+            answer.save()
+            _set_response(registration, True)
+            messages.success(request, "Thank you for completing the diversity survey!")
+            return redirect('../')
+    else:
+        form = DiversitySurveyForm()
+
+    return render_conference_response(request, conference, 'reg', 'confreg/diversity_survey.html', {
+        'form': form,
+        'already_submitted': False,
+        'declined': registration.diversity_survey_response is False,
+    })
+
+
+def _build_survey_aggregate(conference):
+    answers = DiversitySurveyAnswer.objects.filter(conference=conference)
+    regs = ConferenceRegistration.objects.filter(conference=conference)
+    submitted = answers.count()
+    declined = regs.filter(diversity_survey_response=False).count()
+
+    def pct(n):
+        return round(n * 100.0 / submitted, 1) if submitted else 0.0
+
+    sections = []
+    for field_name in _AGGREGATE_FIELDS:
+        field = DiversitySurveyAnswer._meta.get_field(field_name)
+        labels = OrderedDict(field.choices)
+        counts = dict(answers.values_list(field_name).annotate(n=Count('id')))
+        rows = [(label, counts.get(value, 0), pct(counts.get(value, 0)))
+                for value, label in labels.items()]
+        sections.append({'label': field.verbose_name, 'rows': rows})
+
+    accessibility_notes = list(answers.exclude(accessibility_needs='').values_list('accessibility_needs', flat=True))
+    return submitted, declined, sections, accessibility_notes
+
+
+def diversity_survey_report(request, urlname):
+    conference = get_authenticated_conference(request, urlname)
+    submitted, declined, sections, accessibility_notes = _build_survey_aggregate(conference)
+
+    if request.GET.get('format') == 'csv':
+        resp = HttpResponse(content_type='text/csv; charset=utf-8')
+        resp['Content-Disposition'] = 'attachment; filename="diversity_survey_{}.csv"'.format(conference.urlname)
+        w = csv.writer(resp, delimiter=';', quoting=csv.QUOTE_ALL)
+        w.writerow([_csv_safe(v) for v in ['Diversity survey report', conference.conferencename]])
+        w.writerow([_csv_safe(v) for v in ['Submitted', submitted]])
+        w.writerow([_csv_safe(v) for v in ['Declined', declined]])
+        for section in sections:
+            w.writerow([])
+            w.writerow([_csv_safe(v) for v in [section['label'], 'Count', 'Percent']])
+            for label, count, percent in section['rows']:
+                w.writerow([_csv_safe(label), _csv_safe(count), _csv_safe('{}%'.format(percent))])
+        if accessibility_notes:
+            w.writerow([])
+            w.writerow([_csv_safe('Accessibility accommodations used')])
+            for note in accessibility_notes:
+                w.writerow([_csv_safe(note)])
+        return resp
+
+    return render(request, 'confreg/admin_diversity_report.html', {
+        'conference': conference,
+        'helplink': 'reports#diversity',
+        'submitted_count': submitted,
+        'declined_count': declined,
+        'sections': sections,
+        'accessibility_notes': accessibility_notes,
+    })

--- a/postgresqleu/confreg/views.py
+++ b/postgresqleu/confreg/views.py
@@ -145,6 +145,9 @@ def _registration_dashboard(request, conference, reg, has_other_multiregs, redir
     if conference.confirmpolicy and not reg.policyconfirmedat:
         return HttpResponseRedirect('{}policy/'.format(redir_root))
 
+    if conference.diversity_survey_enabled and reg.diversity_survey_response is None:
+        return HttpResponseRedirect('{}survey/'.format(redir_root))
+
     mails = _attendeemail_queryset(conference, reg)
 
     wikipagesQ = Q(publicview=True) | Q(viewer_attendee__attendee=request.user) | Q(viewer_regtype__conferenceregistration__attendee=request.user)

--- a/postgresqleu/confreg/views.py
+++ b/postgresqleu/confreg/views.py
@@ -3623,6 +3623,7 @@ def admin_dashboard_single(request, urlname):
             'pending_tweets': ConferenceTweetQueue.objects.filter(conference=conference, sent=False).exists(),
             'pending_tweet_approvals': ConferenceTweetQueue.objects.filter(conference=conference, approved=False).exists(),
             'pending_cancel_requests': ConferenceRegistration.objects.filter(conference=conference, cancelrequestedat__isnull=False, canceledat__isnull=True),
+            'pending_visa_requests': conditional_exec_to_scalar(conference.visa_letter_enabled, "SELECT EXISTS (SELECT 1 FROM confreg_visaletterrequest WHERE conference_id=%(confid)s AND status='pending')", {'confid': conference.id}),
         })
 
 

--- a/postgresqleu/confreg/visa.py
+++ b/postgresqleu/confreg/visa.py
@@ -1,0 +1,260 @@
+import os
+from io import BytesIO
+from datetime import datetime
+
+from django import forms
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import Http404, HttpResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.utils.html import escape
+
+import jinja2
+
+from reportlab.lib.enums import TA_RIGHT
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import Image, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+from postgresqleu.util.image import rescale_image_bytes
+
+from .models import Conference, ConferenceRegistration, VisaLetterRequest
+from .util import get_authenticated_conference, render_conference_response
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+VISA_LETTER_TEMPLATE_PATH = os.path.join(PROJECT_ROOT, 'template', 'confreg', 'visa_letter_template.j2')
+
+
+def _is_speaker(registration):
+    return registration.conference.conferencesession_set.filter(
+        speaker__user=registration.attendee, status__in=[1, 4]).exists()
+
+
+def is_visa_eligible(registration):
+    return (
+        registration.payconfirmedat is not None
+        or registration.is_volunteer
+        or (registration.regtype and registration.regtype.specialtype in ('staff', 'spk', 'spkr'))
+        or _is_speaker(registration)
+    )
+
+
+class VisaLetterRequestForm(forms.ModelForm):
+    class Meta:
+        model = VisaLetterRequest
+        fields = [
+            'passport_name', 'passport_sex', 'date_of_birth', 'passport_number', 'nationality',
+            'home_address', 'embassy_name', 'embassy_address',
+            'entry_date', 'exit_date', 'accommodation', 'contact_info',
+        ]
+        widgets = {
+            'date_of_birth': forms.DateInput(attrs={'type': 'date'}),
+            'entry_date': forms.DateInput(attrs={'type': 'date'}),
+            'exit_date': forms.DateInput(attrs={'type': 'date'}),
+            'passport_name': forms.TextInput(attrs={'size': 60}),
+            'embassy_name': forms.TextInput(attrs={'size': 60}),
+            'accommodation': forms.TextInput(attrs={'size': 60}),
+            'contact_info': forms.TextInput(attrs={'size': 60}),
+        }
+
+    def clean(self):
+        cleaned = super().clean()
+        conf = self.instance.conference
+        entry = cleaned.get('entry_date')
+        exit_ = cleaned.get('exit_date')
+        if entry:
+            if entry > conf.enddate:
+                self.add_error('entry_date', 'Entry date must be before or during the conference.')
+            elif conf.startdate.toordinal() - entry.toordinal() > 30:
+                self.add_error('entry_date', 'Entry date must not be more than a month before the conference starts.')
+        if exit_:
+            if exit_ < conf.startdate:
+                self.add_error('exit_date', 'Exit date must be during or after the conference.')
+            elif exit_.toordinal() - conf.enddate.toordinal() > 30:
+                self.add_error('exit_date', 'Exit date must not be more than a month after the conference ends.')
+        return cleaned
+
+
+@login_required
+@transaction.atomic
+def visa_letter(request, confname):
+    conference = get_object_or_404(Conference, urlname=confname)
+    if not conference.visa_letter_enabled:
+        raise Http404
+    try:
+        registration = ConferenceRegistration.objects.get(
+            conference=conference, attendee=request.user, canceledat__isnull=True)
+    except ConferenceRegistration.DoesNotExist:
+        messages.error(request, "You must have a registration for this conference to request a visa letter.")
+        return redirect('/events/{}/'.format(confname))
+    if not is_visa_eligible(registration):
+        messages.error(request, "Visa letters are available to attendees with full payment confirmed, speakers, volunteers, and conference staff.")
+        return redirect('/events/{}/'.format(confname))
+
+    visa_request = VisaLetterRequest.objects.filter(
+        conference=conference, registration=registration).first()
+    editable = visa_request is None or visa_request.status == VisaLetterRequest.STATUS_CHANGES_NEEDED
+    form = None
+    if editable:
+        instance = visa_request or VisaLetterRequest(conference=conference, registration=registration)
+        if request.method == 'POST':
+            form = VisaLetterRequestForm(request.POST, instance=instance)
+            if form.is_valid():
+                obj = form.save(commit=False)
+                if visa_request is not None:
+                    obj.status = VisaLetterRequest.STATUS_PENDING
+                obj.save()
+                messages.success(request, "Your visa letter request has been submitted for review.")
+                return redirect('.')
+        else:
+            form = VisaLetterRequestForm(instance=instance)
+
+    return render_conference_response(request, conference, 'reg', 'confreg/visa_letter.html', {
+        'form': form,
+        'visa_request': visa_request,
+    })
+
+
+def admin_visa_letter_generate(request, urlname, requestid):
+    conference = get_authenticated_conference(request, urlname)
+    visa_request = get_object_or_404(
+        VisaLetterRequest,
+        id=requestid,
+        conference=conference,
+        status=VisaLetterRequest.STATUS_APPROVED,
+    )
+    if request.method != 'POST':
+        return redirect('../')
+
+    sig = request.FILES.get('signature')
+    if not sig:
+        messages.error(request, "Please upload a signature image.")
+    elif not sig.content_type.startswith('image/'):
+        messages.error(request, "The uploaded file must be an image (PNG or JPEG).")
+    elif sig.size > 2 * 1024 * 1024:
+        messages.error(request, "The signature image must be smaller than 2 MB.")
+    else:
+        pdf_bytes = generate_visa_letter_pdf(visa_request, sig.read())
+        response = HttpResponse(pdf_bytes, content_type='application/pdf')
+        response['Content-Disposition'] = 'attachment; filename="visa_letter_{}_{}.pdf"'.format(
+            conference.urlname, visa_request.registration.lastname)
+        return response
+    return redirect('../')
+
+
+def _render_letter_body(visa_request):
+    conference = visa_request.conference
+    if conference.startdate == conference.enddate:
+        confdates = conference.startdate.strftime('%B %d, %Y')
+    else:
+        confdates = '{} – {}'.format(
+            conference.startdate.strftime('%B %d'),
+            conference.enddate.strftime('%B %d, %Y'),
+        )
+    is_speaker = _is_speaker(visa_request.registration)
+
+    with open(VISA_LETTER_TEMPLATE_PATH, 'r', encoding='utf-8') as f:
+        template = jinja2.Template(f.read())
+    return template.render(
+        conference={
+            'name': conference.conferencename,
+            'dates': confdates,
+            'venue': conference.location,
+            'city': conference.visa_letter_city,
+            'country': conference.visa_letter_country,
+        },
+        full_name_passport=visa_request.passport_name,
+        passport_sex=visa_request.passport_sex,
+        date_of_birth=visa_request.date_of_birth.strftime('%d/%m/%Y'),
+        nationality=visa_request.nationality,
+        passport_number=visa_request.passport_number,
+        address=visa_request.home_address,
+        entry_date=visa_request.entry_date.strftime('%d/%m/%Y'),
+        exit_date=visa_request.exit_date.strftime('%d/%m/%Y'),
+        stay_at=visa_request.accommodation,
+        contact=visa_request.contact_info,
+        is_speaker=is_speaker,
+        accommodation_covered=visa_request.accommodation_covered,
+        signer={'signature_text': conference.visa_letter_signer},
+    )
+
+
+def generate_visa_letter_pdf(visa_request, signature_bytes):
+    buf = BytesIO()
+    doc = SimpleDocTemplate(buf, pagesize=A4,
+                            rightMargin=72, leftMargin=72,
+                            topMargin=72, bottomMargin=72)
+    styles = getSampleStyleSheet()
+    body = ParagraphStyle('body', parent=styles['Normal'], fontSize=10, leading=12, spaceAfter=6)
+    right = ParagraphStyle('right', parent=body, alignment=TA_RIGHT)
+
+    today = datetime.now().strftime('%B %d, %Y')
+    story = []
+
+    from PIL import Image as PILImage
+    logo_path = os.path.join(PROJECT_ROOT, 'media', 'img', 'pgeu_logo.png')
+    with PILImage.open(logo_path) as _img:
+        ratio = _img.size[0] / _img.size[1]
+    target_height = 0.85 * inch
+    logo_element = Image(logo_path, width=target_height * ratio, height=target_height)
+    logo_element.hAlign = 'LEFT'
+    address_html = (
+        '<b>PostgreSQL Europe</b><br/>'
+        '61, rue de Lyon<br/>'
+        '75012 PARIS<br/>'
+        'FRANCE<br/>'
+        'Website: https://www.postgresql.eu/<br/>'
+        'Email: board@postgresql.eu'
+    )
+    story.append(Table(
+        [[logo_element, Paragraph(address_html, body)]],
+        colWidths=[4.0 * inch, 2.25 * inch],
+        style=TableStyle([
+            ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+            ('LEFTPADDING', (0, 0), (-1, -1), 0),
+            ('RIGHTPADDING', (0, 0), (-1, -1), 0),
+        ]),
+    ))
+    story.append(Spacer(1, 24))
+
+    embassy_html = '{}<br/>{}'.format(
+        escape(visa_request.embassy_name),
+        escape(visa_request.embassy_address).replace('\n', '<br/>'),
+    )
+    story.append(Table(
+        [[Paragraph(embassy_html, body), Paragraph(today, right)]],
+        colWidths=[3.5 * inch, 2.5 * inch],
+        style=TableStyle([
+            ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+            ('LEFTPADDING', (0, 0), (-1, -1), 0),
+            ('RIGHTPADDING', (0, 0), (-1, -1), 0),
+        ]),
+    ))
+    story.append(Spacer(1, 20))
+
+    scaled = rescale_image_bytes(signature_bytes, (250, 100))
+    letter_content = _render_letter_body(visa_request)
+    for para in letter_content.strip().split('\n\n'):
+        chunk = para.strip()
+        if not chunk:
+            continue
+        if '[SIGNATURE_PLACEHOLDER]' in chunk:
+            before, after = chunk.split('[SIGNATURE_PLACEHOLDER]', 1)
+            if before.strip():
+                story.append(Paragraph(before.strip().replace('\n', ' '), body))
+                story.append(Spacer(1, 6))
+            sig = Image(BytesIO(scaled), width=2.2 * inch, height=0.9 * inch)
+            sig.hAlign = 'LEFT'
+            story.append(sig)
+            story.append(Spacer(1, 6))
+            if after.strip():
+                story.append(Paragraph(after.strip().replace('\n', '<br/>'), body))
+        else:
+            story.append(Paragraph(chunk.replace('\n', ' '), body))
+
+    doc.build(story)
+    return buf.getvalue()

--- a/postgresqleu/urls.py
+++ b/postgresqleu/urls.py
@@ -20,6 +20,7 @@ import postgresqleu.confreg.twitter
 import postgresqleu.confreg.api
 import postgresqleu.confreg.upload
 import postgresqleu.confreg.visa
+import postgresqleu.confreg.survey
 import postgresqleu.confsponsor.scanning
 import postgresqleu.confwiki.views
 import postgresqleu.account.views
@@ -117,6 +118,7 @@ urlpatterns.extend([
     re_path(r'^events/([^/]+)/feedback/(\d+)/$', postgresqleu.confreg.views.feedback_session),
     re_path(r'^events/([^/]+)/feedback/conference/$', postgresqleu.confreg.views.feedback_conference),
     re_path(r'^events/([^/]+)/register/visa/$', postgresqleu.confreg.visa.visa_letter),
+    re_path(r'^events/([^/]+)/register/survey/$', postgresqleu.confreg.survey.diversity_survey),
     re_path(r'^events/([^/]+)/schedule/$', postgresqleu.confreg.views.schedule),
     re_path(r'^events/([^/]+)/schedule/fav/$', postgresqleu.confreg.views.schedule_favorite),
     re_path(r'^events/([^/]+)/schedule/ical/$', postgresqleu.confreg.views.schedule_ical),
@@ -185,6 +187,7 @@ urlpatterns.extend([
     re_path(r'^events/admin/([^/]+)/reports/$', postgresqleu.confreg.views.reports),
     re_path(r'^events/admin/([^/]+)/reports/simple/$', postgresqleu.confreg.views.simple_report),
     re_path(r'^events/admin/([^/]+)/reports/feedback/$', postgresqleu.confreg.feedback.feedback_report),
+    re_path(r'^events/admin/([^/]+)/reports/diversity/$', postgresqleu.confreg.survey.diversity_survey_report),
     re_path(r'^events/admin/([^/]+)/reports/feedback/session/$', postgresqleu.confreg.feedback.feedback_sessions),
     re_path(r'^events/admin/([^/]+)/reports/schedule/$', postgresqleu.confreg.pdfschedule.pdfschedule),
     re_path(r'^events/admin/newconference/$', postgresqleu.confreg.backendviews.new_conference),

--- a/postgresqleu/urls.py
+++ b/postgresqleu/urls.py
@@ -19,6 +19,7 @@ import postgresqleu.confreg.checkin
 import postgresqleu.confreg.twitter
 import postgresqleu.confreg.api
 import postgresqleu.confreg.upload
+import postgresqleu.confreg.visa
 import postgresqleu.confsponsor.scanning
 import postgresqleu.confwiki.views
 import postgresqleu.account.views
@@ -115,6 +116,7 @@ urlpatterns.extend([
     re_path(r'^events/([^/]+)/feedback/$', postgresqleu.confreg.views.feedback),
     re_path(r'^events/([^/]+)/feedback/(\d+)/$', postgresqleu.confreg.views.feedback_session),
     re_path(r'^events/([^/]+)/feedback/conference/$', postgresqleu.confreg.views.feedback_conference),
+    re_path(r'^events/([^/]+)/register/visa/$', postgresqleu.confreg.visa.visa_letter),
     re_path(r'^events/([^/]+)/schedule/$', postgresqleu.confreg.views.schedule),
     re_path(r'^events/([^/]+)/schedule/fav/$', postgresqleu.confreg.views.schedule_favorite),
     re_path(r'^events/([^/]+)/schedule/ical/$', postgresqleu.confreg.views.schedule_ical),
@@ -266,6 +268,8 @@ urlpatterns.extend([
     re_path(r'^events/admin/(\w+)/scheduleslots/(.*/)?$', postgresqleu.confreg.backendviews.edit_scheduleslots),
     re_path(r'^events/admin/(\w+)/volunteerslots/(.*/)?$', postgresqleu.confreg.backendviews.edit_volunteerslots),
     re_path(r'^events/admin/(\w+)/feedbackquestions/(.*/)?$', postgresqleu.confreg.backendviews.edit_feedbackquestions),
+    re_path(r'^events/admin/(\w+)/visaletters/(\d+)/generate/$', postgresqleu.confreg.visa.admin_visa_letter_generate),
+    re_path(r'^events/admin/(\w+)/visaletters/(.*/)?$', postgresqleu.confreg.backendviews.edit_visaletters),
     re_path(r'^events/admin/(\w+)/discountcodes/(.*/)?$', postgresqleu.confreg.backendviews.edit_discountcodes),
     re_path(r'^events/admin/(\w+)/messaging/(.*/)?$', postgresqleu.confreg.backendviews.edit_messaging),
     re_path(r'^events/admin/(\w+)/accesstokens/(.*/)?$', postgresqleu.confreg.backendviews.edit_accesstokens),

--- a/template.jinja/confreg/diversity_survey.html
+++ b/template.jinja/confreg/diversity_survey.html
@@ -1,0 +1,43 @@
+{%extends "base.html" %}
+{%block title%}Diversity Survey - {{conference}}{%endblock%}
+{%block content%}
+<h1>Diversity Survey<span class="confheader"> - {{conference}}</span></h1>
+
+{%if already_submitted %}
+<p>You have already submitted the diversity survey for this conference. <b>Thank you!</b></p>
+<p>Your submission is anonymous and cannot be linked back to you, so it cannot be edited or removed individually.</p>
+<p><a href="../">Back to your registration dashboard.</a></p>
+
+{%else %}
+
+<div class="alert alert-info">
+  <p><b>Anonymous diversity survey.</b> This survey helps us understand who attends our conferences and improve future events. <b>Your answers are stored without any link to your identity</b> &mdash; we record that you responded (so we don't ask again), but the response itself cannot be traced back to you.</p>
+  <p>Every question is optional &mdash; every dropdown has a &ldquo;Prefer not to say&rdquo; option, and you may skip the survey entirely.</p>
+</div>
+
+{%if declined %}
+<p>You previously chose to skip this survey. You can still take it now if you've changed your mind.</p>
+{%endif%}
+
+{%if form.errors %}
+<p><b style="color:red;">Please correct the errors below.</b></p>
+{%endif%}
+<form method="post" action=".">{{ csrf_input }}
+<table>
+{%for field in form %}
+ <tr>
+  <th>{{ field.label_tag() }}</th>
+  <td>{{ field.errors }}{{ field }}
+  {%if field.help_text %}<br/><small>{{ field.help_text }}</small>{%endif%}
+  </td>
+ </tr>
+{%endfor%}
+</table>
+<p>
+ <input type="submit" value="Submit survey">
+ <input type="submit" name="skip" value="Skip &mdash; don't show me this again" formnovalidate>
+</p>
+</form>
+{%endif%}
+
+{%endblock%}

--- a/template.jinja/confreg/registration_dashboard.html
+++ b/template.jinja/confreg/registration_dashboard.html
@@ -144,6 +144,18 @@ spamfilters.
    </p>
  </dd>
 {%endif%}
+{%if conference.diversity_survey_enabled and reg.diversity_survey_response is not none %}
+ <dt>Diversity survey</dt>
+ <dd>
+   <p>
+{%if reg.diversity_survey_response %}
+     You have completed the anonymous diversity survey. Thank you!
+{%else %}
+     You chose to skip the anonymous diversity survey. <a href="{{ redir_root }}survey/">Take it now</a> if you've changed your mind.
+{%endif%}
+   </p>
+ </dd>
+{%endif%}
  <dt>Registration details</dt>
  <dd>
    <p>

--- a/template.jinja/confreg/registration_dashboard.html
+++ b/template.jinja/confreg/registration_dashboard.html
@@ -135,6 +135,15 @@ spamfilters.
    </p>
  </dd>
 {%endif%}
+{%if conference.visa_letter_enabled %}
+ <dt>Visa letter</dt>
+ <dd>
+   <p>
+     If you need a letter of invitation to support a visa application,
+     <a href="{{ redir_root }}visa/">request or view the status of your visa letter</a>.
+   </p>
+ </dd>
+{%endif%}
  <dt>Registration details</dt>
  <dd>
    <p>

--- a/template.jinja/confreg/visa_letter.html
+++ b/template.jinja/confreg/visa_letter.html
@@ -1,0 +1,59 @@
+{%extends "base.html" %}
+{%block title%}Visa Letter Request - {{conference}}{%endblock%}
+{%block content%}
+<h1>Visa Letter Request<span class="confheader"> - {{conference}}</span></h1>
+
+{%if visa_request %}
+<h2>Status</h2>
+<dl>
+ <dt>Submitted</dt><dd>{{ visa_request.created_at|datetimeformat("%Y-%m-%d %H:%M") }}</dd>
+ <dt>Status</dt><dd>{{ visa_request.get_status_display() }}</dd>
+{%if visa_request.reviewed_at %}
+ <dt>Reviewed</dt><dd>{{ visa_request.reviewed_at|datetimeformat("%Y-%m-%d %H:%M") }}</dd>
+{%endif%}
+</dl>
+
+{%if visa_request.status == 'pending' %}
+<p>Your visa letter request has been received and is awaiting review by conference staff.</p>
+{%elif visa_request.status == 'approved' %}
+<p>Your visa letter request has been approved. Conference staff will email the PDF letter to you.</p>
+{%elif visa_request.status == 'rejected' %}
+<p>Your visa letter request was not approved. If you have any questions, please contact the conference organisers at <a href="mailto:{{conference.contactaddr}}">{{conference.contactaddr}}</a>.</p>
+{%elif visa_request.status == 'changes_needed' %}
+<p><b>Conference staff have asked you to update your request before it can be processed.</b></p>
+{%if visa_request.admin_notes %}
+<p><b>Notes from staff:</b></p>
+<blockquote>{{ visa_request.admin_notes }}</blockquote>
+{%endif%}
+<p>Please update the details below and re-submit. Your request will go back to staff for review.</p>
+{%endif%}
+{%endif%}
+
+{%if form %}
+{%if not visa_request %}
+<div class="alert alert-info">
+  <p><b>Important:</b> This form is for requesting an official visa letter to support your visa application. Please ensure all information is accurate as it will appear on the official letter.</p>
+  <p>Visa letters are available to attendees with full payment confirmed, speakers, volunteers, and conference staff.</p>
+</div>
+<p>Provide all details exactly as they appear on your passport.</p>
+{%endif%}
+
+{%if form.errors %}
+<p><b style="color:red;">Please correct the errors below.</b></p>
+{%endif%}
+<form method="post" action=".">{{ csrf_input }}
+<table>
+{%for field in form %}
+ <tr>
+  <th>{{ field.label_tag() }}</th>
+  <td>{{ field.errors }}{{ field }}
+  {%if field.help_text %}<br/><small>{{ field.help_text }}</small>{%endif%}
+  </td>
+ </tr>
+{%endfor%}
+</table>
+<input type="submit" value="{%if visa_request %}Re-submit{%else%}Submit{%endif%} visa letter request">
+</form>
+{%endif%}
+
+{%endblock%}

--- a/template/confreg/admin_dashboard_single.html
+++ b/template/confreg/admin_dashboard_single.html
@@ -28,6 +28,9 @@
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn {%if pending_waitlist%}btn-warning{%else%}btn-default{%endif%} btn-block" href="/events/admin/{{c.urlname}}/waitlist/">Waitlist</a></div>
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn btn-default btn-block" href="/events/admin/{{c.urlname}}/transfer/">Transfer registration</a></div>
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn {%if pending_cancel_requests%}btn-warning{%else%}btn-default{%endif%} btn-block" href="/events/admin/{{c.urlname}}/cancelrequests/">Cancellation requests</a></div>
+{%if c.visa_letter_enabled %}
+  <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn {%if pending_visa_requests%}btn-warning{%else%}btn-default{%endif%} btn-block" href="/events/admin/{{c.urlname}}/visaletters/">Visa letter requests</a></div>
+{%endif%}
 </div>
 <div class="row">
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn btn-default btn-block" href="/events/admin/{{c.urlname}}/mail/">Attendee emails</a></div>

--- a/template/confreg/admin_dashboard_single.html
+++ b/template/confreg/admin_dashboard_single.html
@@ -99,6 +99,9 @@
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn {%if sessions_roomoverlap%}btn-warning{%else%}btn-default{%endif%} btn-block" href="/events/admin/{{c.urlname}}/reports/simple/?report=sessoverlaproom">Rooms with overlapping sessions</a></div>
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn {%if sessions_notrack%}btn-warning{%else%}btn-default{%endif%} btn-block" href="/events/admin/{{c.urlname}}/reports/simple/?report=sessnotrack">Sessions with no track</a></div>
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn btn-default btn-block" href="/events/admin/{{c.urlname}}/reports/simple/?report=popularsess">Most popular sessions</a></div>
+{%if c.diversity_survey_enabled %}
+  <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn btn-default btn-block" href="/events/admin/{{c.urlname}}/reports/diversity/">Diversity survey report</a></div>
+{%endif%}
 {%if conference.queuepartitioning %}
   <div class="col-md-3 col-sm-6 col-xs-12 buttonrow"><a class="btn btn-default btn-block" href="/events/admin/{{c.urlname}}/reports/simple/?report=queuepartitions">Queue partitions</a></div>
 {%endif%}

--- a/template/confreg/admin_diversity_report.html
+++ b/template/confreg/admin_diversity_report.html
@@ -1,0 +1,43 @@
+{%extends "confreg/confadmin_base.html"%}
+{%block title%}Diversity survey report - {{conference}}{%endblock%}
+
+{%block layoutblock%}
+<h1>Diversity survey report</h1>
+<p>Aggregate, anonymous responses for <b>{{conference}}</b>. Individual answers are not stored in a way that can be linked back to attendees.</p>
+
+<p><a class="btn btn-default" href="?format=csv">Download as CSV</a></p>
+
+<div class="row">
+ <div class="col-sm-6">
+  <table class="table">
+   <tr><th>Submitted</th><td>{{submitted_count}}</td></tr>
+   <tr><th>Declined (skipped explicitly)</th><td>{{declined_count}}</td></tr>
+  </table>
+ </div>
+</div>
+
+{%for section in sections %}
+<h2>{{section.label}}</h2>
+<table class="table table-striped" style="max-width:36em;">
+ <thead><tr><th>Answer</th><th style="text-align:right;">Count</th><th style="text-align:right;">Percent</th></tr></thead>
+ <tbody>
+{%for label, count, percent in section.rows %}
+  <tr><td>{{label}}</td><td style="text-align:right;">{{count}}</td><td style="text-align:right;">{{percent}}%</td></tr>
+{%endfor%}
+ </tbody>
+</table>
+{%endfor%}
+
+<h2>Accessibility accommodations used</h2>
+{%if accessibility_notes %}
+<ul>
+{%for note in accessibility_notes %}
+ <li>{{note|linebreaksbr}}</li>
+{%endfor%}
+</ul>
+{%else %}
+<p><i>No notes provided.</i></p>
+{%endif%}
+
+<p><a href="../../">Back to admin dashboard</a></p>
+{%endblock%}

--- a/template/confreg/visa_letter_template.j2
+++ b/template/confreg/visa_letter_template.j2
@@ -1,0 +1,51 @@
+Dear Sir or Madam:
+
+I represent PostgreSQL Europe, a not-for-profit association dedicated to
+the promotion of the PostgreSQL Open Source database project within
+Europe, registered in France. We are holding one of our main annual
+conferences, {{ conference.name }}, on the {{ conference.dates }} in the 
+{{ conference.venue }}.
+
+Please accept this letter in support of the short stay visa application
+of <b>{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}</b>
+to travel to {{ conference.city }}, {{ conference.country }} in order to {% if is_speaker %}give a presentation
+at the {% else %}attend the {% endif %}{{ conference.name }} conference.
+{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}
+will be in {{ conference.country }} from {{ entry_date }} to {{ exit_date }}.
+
+{% if accommodation_covered %}
+PostgreSQL Europe will be responsible for all accommodation and travel
+expenses. Accommodation will be paid by PostgreSQL Europe directly,
+travel expenses will be reimbursed after the event.
+{% else %}
+{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}
+will be responsible for all {% if passport_sex == 'male' %}his{% else %}her{% endif %}
+accommodation and travel expenses.
+{% if is_speaker %}As a speaker at the event, {% if passport_sex == 'male' %}his{% else %}her{% endif %}
+registration fees are waived.
+{% else %}{% if passport_sex == 'male' %}His{% else %}Her{% endif %} registration
+fees for the events are paid in full.{% endif %} While in {{ conference.country }},
+{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}
+will be staying at {{ stay_at }}.
+{% if passport_sex == 'male' %}Mr{% else %}Ms{% endif %} {{ full_name_passport }}
+can be reached there at {{ contact }}.
+{% endif %}
+
+Full name as shown on passport: {{ full_name_passport }}<br/>
+Date of birth (DD/MM/YYYY): {{ date_of_birth }}<br/>
+Nationality: {{ nationality }}<br/>
+Passport no: {{ passport_number }}<br/>
+Address: {{ address }}
+
+{{ conference.name }} is one of the main conferences held every year by
+PostgreSQL Europe, and is held every year in a European City. PostgreSQL 
+is a global project and we welcome developers and users from around the 
+world to share experiences and plans at our events.
+
+We thank you for your consideration of our request.
+
+Yours faithfully,
+
+[SIGNATURE_PLACEHOLDER]
+
+{{ signer.signature_text|e|replace('\n', '<br/>')|safe }}


### PR DESCRIPTION
Builds on top of #227: Shared changes to `Conference`,`_safe_attributes`, `backendforms.py` and `backendviews.py`. 
Merge after #227, and the visa commit will drop out of this PR's diff.

Anonymity guarantees:

* `DiversitySurveyAnswer` has no FK to User/Registration and no timestamp to correlate
* `Responded` is just a boolean on `ConferenceRegistration`
* `_set_response()` uses `.update()` so `lastmodified` doesn't reveal submission time
* Conf purge action clears the flag BUT keeps anonymous answers
* Reports are aggregate-only

Also:
* Every field offers "Prefer not to say" option
* Free text fields defanged against CSV formula injection