### PR TITLE
Rewind uploaded file before reading in ImageBinaryFormField

### DIFF
--- a/postgresqleu/util/forms.py
+++ b/postgresqleu/util/forms.py
@@ -181,6 +181,11 @@ class ImageBinaryFormField(forms.Field):
             return None
         if value is None:
             return None
+        # value is an UploadedFile. to_python() can run more than once per
+        # request (e.g. Field.has_changed() -> changed_data, or a second
+        # full_clean()), so rewind before reading to avoid returning b'' on a
+        # subsequent pass.
+        value.seek(0)
         return value.read()
 
     def prepare_value(self, value):


### PR DESCRIPTION
to_python() read the UploadedFile without seeking to 0 first. Since the field extends forms.Field, has_changed()/changed_data or a repeated full_clean() can trigger a second read() that returns b'' (pointer at EOF), silently saving an empty image. Seek before reading to make the field robust regardless of form flow.

The current speaker forms happen to validate only once and never touch changed_data, so this is latent rather than an active bug here.

Discovered while porting the ImageBinaryField machinery to pgweb.